### PR TITLE
Blender 2.80 support clean PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# OpenMW OSGT exporter for Blender
+# OpenMW OpenSceneGraph exporter for Blender
 
-OpenMW OSGT exporter for [Blender](https://www.blender.org), making the
+OpenMW OpenSceneGraph exporter for [Blender](https://www.blender.org), making the
 format viable for importing meshes into [OpenMW](https://openmw.org)
 using a libre format.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
-### Status - DISCONTINUED
+# OpenMW OSGT exporter for Blender
 
-Follow instruction from github to get the repository
+OpenMW OSGT exporter for [Blender](https://www.blender.org), making the
+format viable for importing meshes into [OpenMW](https://openmw.org)
+using a libre format.
 
-https://github.com/cedricpinson/osgexport
+This is a fork of the [Blender OpenSceneGraph Exporter](https://github.com/cedricpinson/osgexport/) updated for 2.80+ Blender versions and
+adjusted to support the specifics of Blender to OpenMW asset pipeline.
 
-## Installation (blender 2.7+)
+## Installation (Blender 2.8+)
 
-To install last version of the exporter go in user preference, then 'Install from File' in the Add-ons tab with the zip from https://github.com/cedricpinson/osgexport/releases
+1. Copy the `osg` directory to the location where Blender stores the
+   scripts/addons folder on your system (you should see other io_scene_*
+   folders there from other addons). Copy the entire dir and not just its
+   contents.
+2. Go to the Blender settings and enable the "OpenMW Native" addon.
 
 ## Command line usage
 
@@ -21,12 +28,6 @@ $ BlenderExporter="/path-to-osgexport/blender-2.5/exporter" \
     [--apply-modifiers] [--enable-animation] [--json-materials] [--enable-animation] \
     [--bake-all] [--bake-quaternions]
 ```
-
-## How to report a bug
-
-Open an [issue](https://github.com/cedricpinson/osgexport/issues/new) and send a minimal blender file that produce the problem.
-
-
 ## Tests
 
 To run tests:

--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -25,21 +25,18 @@ from bpy_extras.io_utils import ExportHelper
 
 
 bl_info = {
-    "name": "Export OSG format (.osgt)",
-    "author": "Cedric Pinson, Jeremy Moles, Peter Amstutz",
+    "name": "OpenMW OpenSceneGraph (.osgt)",
+    "author": "Cedric Pinson, Jeremy Moles, Peter Amstutz, OpenMW",
     "version": (0, 16, 0),
     "blender": (2, 80, 0),
-    "email": "trigrou@gmail.com, jeremy@emperorlinux.com, peter.amstutz@tseboston.com",
     "api": 36339,
     "location": "File > Export > OSG Model (*.osgt)",
-    "description": "Export models and animations for use in OpenSceneGraph",
+    "description": "Export models to OpenMW in OpenSceneGraph's native format.",
     "warning": "",
-    "wiki_url": "https://github.com/cedricpinson/osgexport/wiki",
-    "tracker_url": "http://github.com/cedricpinson/osgexport",
+    "tracker_url": "https://github.com/OpenMW/osgexport/",
     "category": "Import-Export"}
 
-__url__ = bl_info["wiki_url"]
-__email__ = bl_info["email"]
+__url__ = bl_info["tracker_url"]
 __author__ = bl_info["author"]
 __bpydoc__ = bl_info["description"]
 __version__ = bl_info["version"]
@@ -125,7 +122,7 @@ def menu_export_osg_model(self, context):
     # default_path = os.path.splitext(bpy.data.filepath)[0] + "_" + bpy.context.scene.name
     # default_path = default_path.replace('.', '_')
     # self.layout.operator(OSGGUI.bl_idname, text="OSG Model(.osg)").filepath = default_path
-    self.layout.operator(OSGGUI.bl_idname, text="OpenMW Native (.osgt)")
+    self.layout.operator(OSGGUI.bl_idname, text="OpenMW OpenSceneGraph (.osgt)")
 
 
 from bpy.props import *
@@ -166,13 +163,13 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     
     SELECTED : BoolProperty(
         name="Only Export Selected",
-        description="Only export the selected model",
+        description="Export selected objects only",
         default=False
         )
     
     ONLY_VISIBLE : BoolProperty(
         name="Only Export Visible",
-        description="Only export the visible models",
+        description="Export visible objects only",
         default=False
         )
     
@@ -208,25 +205,13 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     
     APPLYMODIFIERS : BoolProperty(
         name="Apply Modifiers",
-        description="Apply modifiers before exporting yes/no",
+        description="Apply modifiers to mesh objects, except for the Armature modifier",
         default=True
         )
     
     LOG : BoolProperty(
         name="Write log",
-        description="Write log file yes/no",
-        default=False
-        )
-    
-    JSON_MATERIALS : BoolProperty(
-        name="JSON Materials",
-        description="Export materials into JSON userdata.",
-        default=False
-        )
-    
-    JSON_SHADERS : BoolProperty(
-        name="JSON shaders",
-        description="Export shader graphs into JSON userdata.",
+        description="Write log file",
         default=False
         )
     
@@ -258,18 +243,18 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     
     ARMATURE_REST : BoolProperty(
         name="Export armature in REST pose",
-        description="Static armatures are exported in REST mode (instead of POSE)",
+        description="Static armatures are exported in REST mode instead of POSE mode",
         default=False
         )
     
     OSGCONV_TO_IVE : BoolProperty(
         name="Convert to IVE (uses osgconv)",
-        description="Use osgconv to convert to IVE",
+        description="Use osgconv to convert the exported file to OpenSceneGraph's IVE format",
         default=False
         )
     
     OSGCONV_EMBED_TEXTURES : BoolProperty(
-        name="Embed textures in IVE",
+        name="Embed textures in the IVE format",
         default=False
         )
     
@@ -318,7 +303,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     
     EXPORT_TEXTURES : BoolProperty(
         name="Export Textures",
-        description="Create a folder containing used textures at the same location as the exported file.",
+        description="Create a textures folder in the same location as the exported file",
         default=False
         )
 
@@ -358,8 +343,6 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.OSGCONV_EMBED_TEXTURES = self.config.osgconv_embed_textures
         self.OSGCONV_PATH = self.config.osgconv_path
         self.OSGCONV_CLEANUP = self.config.osgconv_cleanup
-        self.JSON_MATERIALS = self.config.json_materials
-        self.JSON_SHADERS = self.config.json_shaders
 
         self.RUN_VIEWER = self.config.run_viewer
         self.VIEWER_PATH = self.config.viewer_path
@@ -606,9 +589,6 @@ class OSGT_PT_export_material(bpy.types.Panel):
         operator = sfile.active_operator
         
         col = layout.column(align = True)
-        col.prop(operator, 'JSON_MATERIALS')
-        col.prop(operator, 'JSON_SHADERS')
-        col.prop(operator, 'TEXTURE_PREFIX')
 
 
 class OSGT_PT_export_extra(bpy.types.Panel):

--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -315,6 +315,12 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         min=0.01, max=1000.0,
         default=1.0,
         )
+    
+    EXPORT_TEXTURES : BoolProperty(
+        name="Export Textures",
+        description="Create a folder containing used textures at the same location as the exported file.",
+        default=False
+        )
 
     def draw(self, context):
         pass
@@ -360,6 +366,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.TEXTURE_PREFIX = self.config.texture_prefix
         self.EXPORT_ALL_SCENES = self.config.export_all_scenes
         self.SCALE_FACTOR = self.config.scale_factor
+        self.EXPORT_TEXTURES = self.config.export_textures
 
         if bpy.data.filepath in self.config.history:
             self.filepath = self.config.history[bpy.data.filepath]
@@ -399,6 +406,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.export_all_scenes = self.EXPORT_ALL_SCENES
         self.config.osgconv_cleanup = self.OSGCONV_CLEANUP
         self.config.scale_factor = self.SCALE_FACTOR
+        self.config.export_textures = self.EXPORT_TEXTURES
 
         try:
             cfg = os.path.join(bpy.utils.user_resource('CONFIG'), "osgExport.cfg")
@@ -450,6 +458,7 @@ class OSGT_PT_export_include(bpy.types.Panel):
         col = layout.column(heading = "Limit to", align = True)
         col.prop(operator, 'SELECTED', text="Selected Objects")
         col.prop(operator, 'ONLY_VISIBLE', text="Visible Objects")
+        col.prop(operator, 'EXPORT_TEXTURES')
         #col.prop(operator, 'EXPORT_ALL_SCENES', text="All Scenes")
         
         #col = layout.column(align = False)

--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -125,7 +125,7 @@ def menu_export_osg_model(self, context):
     # default_path = os.path.splitext(bpy.data.filepath)[0] + "_" + bpy.context.scene.name
     # default_path = default_path.replace('.', '_')
     # self.layout.operator(OSGGUI.bl_idname, text="OSG Model(.osg)").filepath = default_path
-    self.layout.operator(OSGGUI.bl_idname, text="OSGT(.osgt)")
+    self.layout.operator(OSGGUI.bl_idname, text="OpenMW Native (.osgt)")
 
 
 from bpy.props import *
@@ -342,7 +342,6 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
 
         self.EXPORTANIM = self.config.export_anim
         self.APPLYMODIFIERS = self.config.apply_modifiers
-        self.ZERO_TRANSLATIONS = self.config.zero_translations
         self.LOG = self.config.log
         self.BAKE_ALL = self.config.bake_animations
         self.USE_QUATERNIONS = self.config.use_quaternions
@@ -360,6 +359,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.VIEWER_PATH = self.config.viewer_path
         self.TEXTURE_PREFIX = self.config.texture_prefix
         self.EXPORT_ALL_SCENES = self.config.export_all_scenes
+        self.SCALE_FACTOR = self.config.scale_factor
 
         if bpy.data.filepath in self.config.history:
             self.filepath = self.config.history[bpy.data.filepath]
@@ -385,7 +385,6 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.export_anim = self.EXPORTANIM
         self.config.apply_modifiers = self.APPLYMODIFIERS
         self.config.log = self.LOG
-        self.config.zero_translations = self.ZERO_TRANSLATIONS
         self.config.bake_animations = self.BAKE_ALL
         self.config.use_quaternions = self.USE_QUATERNIONS
         self.config.bake_constraints = self.BAKE_CONSTRAINTS
@@ -399,6 +398,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.osgconv_embed_textures = self.OSGCONV_EMBED_TEXTURES
         self.config.export_all_scenes = self.EXPORT_ALL_SCENES
         self.config.osgconv_cleanup = self.OSGCONV_CLEANUP
+        self.config.scale_factor = self.SCALE_FACTOR
 
         try:
             cfg = os.path.join(bpy.utils.user_resource('CONFIG'), "osgExport.cfg")
@@ -422,6 +422,9 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
 
         return {'FINISHED'}
 
+
+# USER INTERFACE ===============================================================================
+# ==============================================================================================
 
 class OSGT_PT_export_include(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -476,8 +479,7 @@ class OSGT_PT_export_transform(bpy.types.Panel):
         operator = sfile.active_operator
         
         col = layout.column(align = False)        
-        #col.prop(operator, 'SCALE_FACTOR')
-        col.prop(operator, 'ZERO_TRANSLATIONS')
+        col.prop(operator, 'SCALE_FACTOR')
 
 
 class OSGT_PT_export_geometry(bpy.types.Panel):

--- a/exporter/osg/osgbake.py
+++ b/exporter/osg/osgbake.py
@@ -46,7 +46,8 @@ def bakeMorphTargets(frame_start,
         'Collect shape keys factors for each frame in frame range'
         for f in frame_range:
             scene.frame_set(f)
-            scene.update()
+            bpy.context.view_layer.update()
+            #scene.update() 2.79
             for block in morph_info:
                 morph_info[block].append(block.value)
 
@@ -79,7 +80,8 @@ def bakeMorphTargets(frame_start,
         keyFrames = [block.frame for block in shape.key_blocks]
         for f in frame_range:
             scene.frame_set(f)
-            scene.update()
+            bpy.context.view_layer.update()
+            #scene.update() 2.79
             values = evaluateActiveShapeKeys(shape.eval_time, keyFrames)
             for block in morph_info:
                 if block == values['previous']:
@@ -121,7 +123,8 @@ def bakeMorphTargets(frame_start,
     cleanAction(new_action)
     shape.animation_data.action = original_action
     scene.frame_set(frame_back)
-    scene.update()
+    bpy.context.view_layer.update()
+    #scene.update() 2.79
 
     return new_action
 
@@ -234,7 +237,8 @@ def bakeAction(blender_object,
     # Collect transformations
     for f in frame_range:
         scene.frame_set(f)
-        scene.update()
+        bpy.context.view_layer.update()
+        #scene.update() 2.79
         if do_pose:
             pose_info.append(poseFrameInfo(blender_object, do_visual_keying))
         if do_object:
@@ -362,11 +366,13 @@ def bakeAction(blender_object,
         # Setting back matrices is required since baking process changes these values
         # and it can affect further constraints bakings. Note that the order is important here
         scene.frame_set(frame_back)
-        scene.update()
+        bpy.context.view_layer.update()
+        #scene.update() 2.79
         blender_object.matrix_parent_inverse = matrix_parent_inverse_backup
         blender_object.matrix_local = matrix_local_backup
         blender_object.matrix_basis = matrix_basis_backup
-        scene.update()
+        bpy.context.view_layer.update()
+        #scene.update() 2.79
 
     # -------------------------------------------------------------------------
     # Clean

--- a/exporter/osg/osgbake.py
+++ b/exporter/osg/osgbake.py
@@ -47,7 +47,6 @@ def bakeMorphTargets(frame_start,
         for f in frame_range:
             scene.frame_set(f)
             bpy.context.view_layer.update()
-            #scene.update() 2.79
             for block in morph_info:
                 morph_info[block].append(block.value)
 
@@ -81,7 +80,6 @@ def bakeMorphTargets(frame_start,
         for f in frame_range:
             scene.frame_set(f)
             bpy.context.view_layer.update()
-            #scene.update() 2.79
             values = evaluateActiveShapeKeys(shape.eval_time, keyFrames)
             for block in morph_info:
                 if block == values['previous']:
@@ -124,7 +122,6 @@ def bakeMorphTargets(frame_start,
     shape.animation_data.action = original_action
     scene.frame_set(frame_back)
     bpy.context.view_layer.update()
-    #scene.update() 2.79
 
     return new_action
 
@@ -238,7 +235,6 @@ def bakeAction(blender_object,
     for f in frame_range:
         scene.frame_set(f)
         bpy.context.view_layer.update()
-        #scene.update() 2.79
         if do_pose:
             pose_info.append(poseFrameInfo(blender_object, do_visual_keying))
         if do_object:
@@ -367,12 +363,10 @@ def bakeAction(blender_object,
         # and it can affect further constraints bakings. Note that the order is important here
         scene.frame_set(frame_back)
         bpy.context.view_layer.update()
-        #scene.update() 2.79
         blender_object.matrix_parent_inverse = matrix_parent_inverse_backup
         blender_object.matrix_local = matrix_local_backup
         blender_object.matrix_basis = matrix_basis_backup
         bpy.context.view_layer.update()
-        #scene.update() 2.79
 
     # -------------------------------------------------------------------------
     # Clean

--- a/exporter/osg/osgconf.py
+++ b/exporter/osg/osgconf.py
@@ -81,6 +81,7 @@ class Config(object):
         self.defaultattr("history", {})
         self.defaultattr("json_materials", False)
         self.defaultattr("json_shaders", False)
+        self.defaultattr("export_textures", False)
 
         self.filepath = ""
         self.fullpath = ""

--- a/exporter/osg/osgconf.py
+++ b/exporter/osg/osgconf.py
@@ -57,7 +57,6 @@ class Config(object):
         self.defaultattr("export_anim", True)
         self.defaultattr("object_selected", None)
 
-        self.defaultattr("zero_translations", False)
         self.defaultattr("apply_modifiers", False)
         self.defaultattr("bake_animations", False)
         self.defaultattr("use_quaternions", False)
@@ -65,6 +64,7 @@ class Config(object):
         self.defaultattr("bake_frame_step", 1)
         self.defaultattr("arm_rest", False)
         self.defaultattr("osgconv_to_ive", False)
+        self.defaultattr("scale_factor", 1)
         osgconv_util = "osgconv"
         if sys.platform == 'win32':
             osgconv_util += ".exe"

--- a/exporter/osg/osgconf.py
+++ b/exporter/osg/osgconf.py
@@ -79,8 +79,6 @@ class Config(object):
         self.defaultattr("osgconv_cleanup", False)
 
         self.defaultattr("history", {})
-        self.defaultattr("json_materials", False)
-        self.defaultattr("json_shaders", False)
         self.defaultattr("export_textures", False)
 
         self.filepath = ""

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1650,7 +1650,11 @@ class BlenderObjectToGeometry(object):
         # 'facevertexindex' is the current vertex of the current face
         # This function is used a bit lower when we iterate over the faces and is used for each face.
         #============================================================================================ 
-        def get_vertex_key(faceindex, facevertexindex):
+        def get_vertex_key(faceindex, facevertexindex):            
+            # we are inputing an index of a face-corner per currently handled face.
+            # However we need to get the index of this face-corner within the mesh
+            # and not relative to the face. Blender calls face_corners loops.
+            loop = mesh.polygons[faceindex].loop_indices[facevertexindex]  
             
             #Get normals
             #===========
@@ -1662,7 +1666,7 @@ class BlenderObjectToGeometry(object):
             #Get VColors
             #===========
             if vertex_colors:
-                vcolors = tuple(getattr(vertex_colors.data[faceindex], 'color{}'.format(facevertexindex + 1)))
+                vcolors = tuple(list(vertex_colors.data[loop].color[:3]))
             else:
                 vcolors = tuple()
             
@@ -1672,15 +1676,11 @@ class BlenderObjectToGeometry(object):
                          #for uv in mesh.tessface_uv_textures] 2.79
             
             texcoords = []
-            # we are inputing face corners of this face, but we need to get the index of this face 
-            # corner within the mesh
-            loop = mesh.polygons[faceindex].loop_indices[facevertexindex]  
             
             for uv in mesh.uv_layers:
                 texcoords.append(tuple(truncateVector(list(uv.data[loop].uv))))
 
             return (face.vertices[facevertexindex], tuple(truncateVector(normal)), tuple(texcoords), vcolors)
-
         # Do stuff on all faces of a mesh
         #================================
         for face in faces:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -770,7 +770,6 @@ class Export(object):
         if self.config.apply_modifiers and has_non_armature_modifiers and not hasShapeKeys(mesh):
             # Blender object and to_mesh() both require to be touched by the dependency graph for this to work
             dg = bpy.context.evaluated_depsgraph_get()
-            mesh = mesh.evaluated_get(dg)
             mesh_object = mesh.evaluated_get(dg).to_mesh(preserve_all_data_layers=True, depsgraph=dg)
             # mesh_object = mesh.to_mesh(self.config.scene, True, 'PREVIEW') 2.79 way
         else:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -359,12 +359,6 @@ class Export(object):
             mtx_util = Matrix([[0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,self.config.scale_factor-1]])
             osg_object.matrix = (matrix.copy() * self.config.scale_factor).normalized() - mtx_util
 
-            if self.config.zero_translations and parent is None:
-                if bpy.app.version[0] >= 2 and bpy.app.version[1] >= 62:
-                    print("zero_translations option has not been converted to blender 2.62")
-                else:
-                    osg_object.matrix[3].xyz = Vector()
-
             self.createAnimationsObject(osg_object, blender_object, self.config,
                                         createAnimationUpdate(blender_object,
                                                               UpdateMatrixTransform(name=osg_object.name),

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -666,53 +666,57 @@ class Export(object):
         with open(filename, "wb") as sfile:
             # sfile.write(str(self.root).encode('utf-8'))
             self.root.writeFile(sfile)
-
-        nativePath = os.path.join(os.path.abspath(self.config.getFullPath()), self.config.texture_prefix)
-        # blenderPath = bpy.path.relpath(nativePath)
-        if len(self.images) > 0:
-            try:
-                if not os.path.exists(nativePath):
-                    os.mkdir(nativePath)
-            except:
-                Log("can't create textures directory {}".format(nativePath))
-                raise
-
-        copied_images = []
-        for i in self.images:
-            if i is not None:
-                imagename = bpy.path.basename(createImageFilename("", i))
+        
+        if self.config.export_textures:
+            # Exported textures folder
+            nativePath = os.path.join(os.path.abspath(self.config.getFullPath()), self.config.texture_prefix)
+            # blenderPath = bpy.path.relpath(nativePath)
+            if len(self.images) > 0:
                 try:
-                    if i.packed_file:
-                        original_filepath = i.filepath_raw
-                        try:
-                            if len(imagename.split('.')) == 1:
-                                imagename += ".png"
-                            filename = os.path.join(nativePath, imagename)
-                            if not os.path.exists(filename):
-                                # record which images that were newly copied and can be safely
-                                # cleaned up
-                                copied_images.append(filename)
-                            i.filepath_raw = filename
-                            Log("packed file, save it to {}"
-                                .format(os.path.abspath(bpy.path.abspath(filename))))
-                            i.save()
-                        except:
-                            Log("failed to save file {} to {}".format(imagename, nativePath))
-                        i.filepath_raw = original_filepath
-                    else:
-                        filepath = os.path.abspath(bpy.path.abspath(i.filepath))
-                        texturePath = os.path.join(nativePath, imagename)
-                        if os.path.exists(filepath):
-                            if not os.path.exists(texturePath):
-                                # record which images that were newly copied and can be safely
-                                # cleaned up
-                                copied_images.append(texturePath)
-                            shutil.copy(filepath, texturePath)
-                            Log("copy file {} to {}".format(filepath, texturePath))
+                    if not os.path.exists(nativePath):
+                        os.mkdir(nativePath)
+                except:
+                    Log("can't create textures directory {}".format(nativePath))
+                    raise
+
+            copied_images = []
+            
+            # Exported textures
+            for i in self.images:
+                if i is not None:
+                    imagename = bpy.path.basename(createImageFilename("", i))
+                    try:
+                        if i.packed_file:
+                            original_filepath = i.filepath_raw
+                            try:
+                                if len(imagename.split('.')) == 1:
+                                    imagename += ".png"
+                                filename = os.path.join(nativePath, imagename)
+                                if not os.path.exists(filename):
+                                    # record which images that were newly copied and can be safely
+                                    # cleaned up
+                                    copied_images.append(filename)
+                                i.filepath_raw = filename
+                                Log("packed file, save it to {}"
+                                    .format(os.path.abspath(bpy.path.abspath(filename))))
+                                i.save()
+                            except:
+                                Log("failed to save file {} to {}".format(imagename, nativePath))
+                            i.filepath_raw = original_filepath
                         else:
-                            Log("file {} not available".format(filepath))
-                except Exception as e:
-                    Log("error while trying to copy file {} to {}: {}".format(imagename, nativePath, e))
+                            filepath = os.path.abspath(bpy.path.abspath(i.filepath))
+                            texturePath = os.path.join(nativePath, imagename)
+                            if os.path.exists(filepath):
+                                if not os.path.exists(texturePath):
+                                    # record which images that were newly copied and can be safely
+                                    # cleaned up
+                                    copied_images.append(texturePath)
+                                shutil.copy(filepath, texturePath)
+                                Log("copy file {} to {}".format(filepath, texturePath))
+                            else:
+                                Log("file {} not available".format(filepath))
+                    except Exception as e:
+                        Log("error while trying to copy file {} to {}: {}".format(imagename, nativePath, e))
 
         filetoview = self.config.getFullName("osgt")
         if self.config.osgconv_to_ive:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1233,7 +1233,7 @@ class BlenderObjectToGeometry(object):
         
          
         if shader is None:
-            material.diffuse = (1.0, 1.0, 1.0, alpha)      
+            material.diffuse = (1.0, 1.0, 1.0, 1.0)      
             material.ambient = (0.0, 0.0, 0.0, 1.0)
             material.specular = (1.0, 1.0, 1.0, 1.0)
             material.emission = (0.0, 0.0, 0.0, 1.0)       

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -768,7 +768,11 @@ class Export(object):
 
         # converting to mesh skips shape keys
         if self.config.apply_modifiers and has_non_armature_modifiers and not hasShapeKeys(mesh):
-            mesh_object = mesh.to_mesh(self.config.scene, True, 'PREVIEW')
+            # Blender object and to_mesh() both require to be touched by the dependency graph for this to work
+            dg = bpy.context.evaluated_depsgraph_get()
+            mesh = mesh.evaluated_get(dg)
+            mesh_object = mesh.evaluated_get(dg).to_mesh(preserve_all_data_layers=True, depsgraph=dg)
+            # mesh_object = mesh.to_mesh(self.config.scene, True, 'PREVIEW') 2.79 way
         else:
             mesh_object = mesh.data
 

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -332,11 +332,9 @@ class Export(object):
             matrix = getDeltaMatrixFrom(blender_object.parent, blender_object)
             osg_object = MatrixTransform()
             osg_object.setName(blender_object.name)            
-            osg_object.matrix = matrix
+            osg_object.matrix = matrix.copy()
             # When scaling the exported result, we want to multiply only object's location values
-            osg_object.matrix[0][3] *= self.config.scale_factor
-            osg_object.matrix[1][3] *= self.config.scale_factor
-            osg_object.matrix[2][3] *= self.config.scale_factor
+            osg_object.matrix.translation *= self.config.scale_factor
             
             lightItem = self.createLight(blender_object)
             self.createAnimationsObject(osg_object, blender_object, self.config,
@@ -357,9 +355,7 @@ class Export(object):
             osg_object.setName(blender_object.name)            
             osg_object.matrix = matrix.copy()
             # When scaling the exported result, we want to multiply only object's location values
-            osg_object.matrix[0][3] *= self.config.scale_factor
-            osg_object.matrix[1][3] *= self.config.scale_factor
-            osg_object.matrix[2][3] *= self.config.scale_factor
+            osg_object.matrix.translation *= self.config.scale_factor
 
             self.createAnimationsObject(osg_object, blender_object, self.config,
                                         createAnimationUpdate(blender_object,

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -242,22 +242,22 @@ class Export(object):
         if item is not None:
             self.items.append(item)
 
-    def evaluateGroup(self, blender_object, item, rootItem):
-        if blender_object.dupli_group is None or len(blender_object.dupli_group.objects) == 0:
+    def evaluateCollection(self, blender_object, item, rootItem):
+        if blender_object.instance_collection is None or len(blender_object.instance_collection.objects) == 0:
             return
 
-        Log("resolving {} for {} offset {}".format(blender_object.dupli_group.name,
+        Log("resolving {} for {} offset {}".format(blender_object.instance_collection.name,
                                                    blender_object.name,
-                                                   blender_object.dupli_group.dupli_offset))
+                                                   blender_object.instance_collection.instance_offset))
 
         group = MatrixTransform()
-        group.matrix = Matrix.Translation(-blender_object.dupli_group.dupli_offset)
+        group.matrix = Matrix.Translation(-blender_object.instance_collection.instance_offset)
         item.children.append(group)
 
         # for group we disable the only visible
         config_visible = self.config.only_visible
         self.config.only_visible = False
-        for o in blender_object.dupli_group.objects:
+        for o in blender_object.instance_collection.objects:
             Log("object {}".format(o))
             self.exportChildrenRecursively(o, group, rootItem)
         self.config.only_visible = config_visible
@@ -373,8 +373,8 @@ class Export(object):
                 if blender_object.type == "MESH":
                     osg_geode = self.createGeodeFromObject(blender_object)
                     osg_object.children.append(osg_geode)
-                else:
-                    self.evaluateGroup(blender_object, osg_object, osg_root)
+                elif blender_object.type == "EMPTY":
+                    self.evaluateCollection(blender_object, osg_object, osg_root)
             return osg_object
 
         def handleBoneChild(blender_object, osg_object):
@@ -1681,6 +1681,7 @@ class BlenderObjectToGeometry(object):
                 texcoords.append(tuple(truncateVector(list(uv.data[loop].uv))))
 
             return (face.vertices[facevertexindex], tuple(truncateVector(normal)), tuple(texcoords), vcolors)
+
         # Do stuff on all faces of a mesh
         #================================
         for face in faces:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1231,7 +1231,6 @@ class BlenderObjectToGeometry(object):
                     shader = node
                     break 
         
-        alpha = 1.0
          
         if shader is None:
             material.diffuse = (1.0, 1.0, 1.0, alpha)      
@@ -1240,7 +1239,11 @@ class BlenderObjectToGeometry(object):
             material.emission = (0.0, 0.0, 0.0, 1.0)       
             material.shininess = 12.5
         elif shader.type == "EEVEE_SPECULAR":
-            stateset.modes["GL_BLEND"] = "OFF"
+            alpha = 1 - shader.inputs[4].default_value
+            if mat_source.blend_method != 'OPAQUE':
+                stateset.modes["GL_BLEND"] = "ON"
+            else:
+                stateset.modes["GL_BLEND"] = "OFF"
             if mat_source.use_backface_culling:
                 stateset.modes["GL_CULL_FACE"] = "FRONT"
             else:
@@ -1249,7 +1252,7 @@ class BlenderObjectToGeometry(object):
             material.diffuse = (shader.inputs[0].default_value[0],
                                 shader.inputs[0].default_value[1],
                                 shader.inputs[0].default_value[2],
-                                1.0)      
+                                alpha)      
             material.ambient = (bpy.context.scene.world.color[0],
                                 bpy.context.scene.world.color[1],
                                 bpy.context.scene.world.color[2],
@@ -1264,7 +1267,11 @@ class BlenderObjectToGeometry(object):
                                  1.0)        
             material.shininess = ((1 - shader.inputs[2].default_value) * 100 / 512 ) * 128    
         elif shader.type == "EMISSION":
-            stateset.modes["GL_BLEND"] = "OFF"
+            alpha = 1.0
+            if mat_source.blend_method != 'OPAQUE':
+                stateset.modes["GL_BLEND"] = "ON"
+            else:
+                stateset.modes["GL_BLEND"] = "OFF"
             if mat_source.use_backface_culling:
                 stateset.modes["GL_CULL_FACE"] = "FRONT"
             else:
@@ -1279,7 +1286,7 @@ class BlenderObjectToGeometry(object):
             material.emission = (0.0, 0.0, 0.0, 1.0)       
             material.shininess = 0
                 
-                
+            
         #if mat_source.use_shadeless:
         #    stateset.modes["GL_LIGHTING"] = "OFF"
 
@@ -1297,8 +1304,8 @@ class BlenderObjectToGeometry(object):
         # if alpha not 1 then we set the blending mode on
         #if DEBUG:
             #Log("state material alpha {}".format(alpha))
-        if alpha != 1.0:
-            stateset.modes["GL_BLEND"] = "ON"
+        #if alpha != 1.0:
+        #    stateset.modes["GL_BLEND"] = "ON"
 
       
         #ambient_factor = mat_source.ambient
@@ -1414,7 +1421,6 @@ class BlenderObjectToGeometry(object):
                 data_texture_slot = data["TextureSlots"].setdefault(i, {})
                 data_texture_slot["BlendType"] = "MIX"
                 stateset.texture_attributes.setdefault(0, []).append(texture)
-                stateset.modes["GL_BLEND"] = "OFF"
                 data_texture_slot["DiffuseColor"] = 1.0
 
                     
@@ -1452,7 +1458,6 @@ class BlenderObjectToGeometry(object):
                 data_texture_slot = data["TextureSlots"].setdefault(i, {})
                 data_texture_slot["BlendType"] = "MIX"
                 stateset.texture_attributes.setdefault(0, []).append(texture)
-                stateset.modes["GL_BLEND"] = "OFF"
                 data_texture_slot["DiffuseColor"] = 1.0       
         
         

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -352,8 +352,18 @@ class Export(object):
             # matrix for our use.
             matrix = getDeltaMatrixFrom(blender_object.parent, blender_object)
             osg_object = MatrixTransform()
-            osg_object.setName(blender_object.name)            
-            osg_object.matrix = matrix.copy()
+            
+            # OpenMW looks for a specific object name to see if it's used for physics collisions
+            # Artist's workflow is that a mesh needs a collision modifier assigned in Blender
+            # and we then replace its exported name so OpenMW uses it for collisions
+            if blender_object.modifiers:
+                for modifier in blender_object.modifiers:
+                    if modifier.type == "COLLISION":
+                        osg_object.setName("collision")
+            else:
+                osg_object.setName(blender_object.name)       
+            
+            osg_object.matrix = matrix.copy()           
             # When scaling the exported result, we want to multiply only object's location values
             osg_object.matrix.translation *= self.config.scale_factor
 

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1592,7 +1592,13 @@ class BlenderObjectToGeometry(object):
             #faces = mesh.faces
             #uv_textures = mesh.uv_textures
         # Checks for Blender version when bmesh was introduced. 2.80 and onwards are far away from that.
-        faces = mesh.polygons
+        
+        mesh.calc_loop_triangles()
+        faces = mesh.loop_triangles
+        # When we don't force triangles but support also quads or polylines.
+        # It fails with ngons though:
+        #faces = mesh.polygons
+        
         uv_textures = mesh.uv_layers
         vertex_colors = mesh.vertex_colors.active
         
@@ -1652,7 +1658,11 @@ class BlenderObjectToGeometry(object):
             # we are inputing an index of a face-corner per currently handled face.
             # However we need to get the index of this face-corner within the mesh
             # and not relative to the face. Blender calls face_corners loops.
-            loop = mesh.polygons[faceindex].loop_indices[facevertexindex]  
+            loop = mesh.loop_triangles[faceindex].loops[facevertexindex] 
+            
+            # When we don't force triangles but support also quads or polylines.
+            # It fails with ngons though:
+            # loop = mesh.polygons[faceindex].loop_indices[facevertexindex]
             
             #Get normals
             #===========

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1240,6 +1240,12 @@ class BlenderObjectToGeometry(object):
             material.emission = (0.0, 0.0, 0.0, 1.0)       
             material.shininess = 12.5
         elif shader.type == "EEVEE_SPECULAR":
+            stateset.modes["GL_BLEND"] = "OFF"
+            if mat_source.use_backface_culling:
+                stateset.modes["GL_CULL_FACE"] = "FRONT"
+            else:
+                stateset.modes["GL_CULL_FACE"] = "OFF"
+            stateset.modes["GL_LIGHTING"] = "ON"
             material.diffuse = (shader.inputs[0].default_value[0],
                                 shader.inputs[0].default_value[1],
                                 shader.inputs[0].default_value[2],
@@ -1258,6 +1264,11 @@ class BlenderObjectToGeometry(object):
                                  1.0)        
             material.shininess = ((1 - shader.inputs[2].default_value) * 100 / 512 ) * 128    
         elif shader.type == "EMISSION":
+            stateset.modes["GL_BLEND"] = "OFF"
+            if mat_source.use_backface_culling:
+                stateset.modes["GL_CULL_FACE"] = "FRONT"
+            else:
+                stateset.modes["GL_CULL_FACE"] = "OFF"
             stateset.modes["GL_LIGHTING"] = "OFF"
             material.diffuse = (shader.inputs[0].default_value[0],
                                 shader.inputs[0].default_value[1],

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -268,10 +268,6 @@ class Export(object):
             return blender_object.name
         return "no name"
 
-    def isObjectVisible(self, blender_object):
-        #return blender_object.visible_get(self.config.scene) or not self.config.only_visible
-        return blender_object.visible_get() or not self.config.only_visible
-
     def createAnimationsObject(self, osg_object, blender_object, config, update_callback, unique_objects,parse_all_actions=False):
         if not config.export_anim or len(bpy.data.actions) == 0:
             return None
@@ -404,7 +400,8 @@ class Export(object):
         # Check if the object is visible. The visibility will be used for meshes and lights
         # to determine if we keep it or not. Other objects have to be taken into account even if they
         # are not visible as they can be used as modifiers (avoiding some crashs during the export)
-        is_visible = self.isObjectVisible(blender_object)
+        # Mesh data is not written while objects still get added as nodes in the scene.
+        is_visible = blender_object.visible_get() or not self.config.only_visible
         Log("")
 
         osg_object = None

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -997,8 +997,13 @@ class BlenderObjectToGeometry(object):
         texture.name = node.image.name
 
         #reference texture relative to export path
-        filename = createImageFilename(self.config.texture_prefix, image_object)
+        #filename = createImageFilename(self.config.texture_prefix, image_object)
+        
+        # OpenMW specific texture path where all textures are in 'data/textures' folder and its subfolders.
+        # Meshes are in 'data/meshes' and their required texture path always starts with 'textures/'
+        filename = image_object.filepath[image_object.filepath.find("data/textures") + len("data/"):]
         texture.file = filename
+        
         texture.source_image = image_object
         self.unique_objects.registerTexture(node, texture)
         return texture

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1601,6 +1601,7 @@ class BlenderObjectToGeometry(object):
         
         uv_textures = mesh.uv_layers
         vertex_colors = mesh.vertex_colors.active
+        mesh.calc_normals_split()
         
         # Check if the mesh has any faces
         #================================
@@ -1667,7 +1668,10 @@ class BlenderObjectToGeometry(object):
             #Get normals
             #===========
             if face.use_smooth:
-                normal = list(mesh.vertices[face.vertices[facevertexindex]].normal)
+                if mesh.has_custom_normals:
+                    normal = list(mesh.loops[loop].normal)
+                else:
+                    normal = list(mesh.vertices[face.vertices[facevertexindex]].normal)
             else:
                 normal = list(face.normal)
             

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1382,18 +1382,18 @@ class BlenderObjectToGeometry(object):
             data["DiffuseShader"] = "LAMBERT"
             data["SpecularShader"] = "COOKTORR"
             data["TextureSlots"] = {}
-            
-            # Textures
-            # We're only writing a single diffuse texture that's required by OpenMW, but the logic is from a more
-            # general system that was already present in the exporter and works with the rest of the code.
+            # We're only writing a single diffuse texture that's required by OpenMW,
+            # but the logic is from a more general system that was already present in
+            # the exporter and works with the rest of the code.
             texture_list = []
             for node in mat_source.node_tree.nodes:
                 if node.type != "TEX_IMAGE":
                     continue
                 elif not node.image:
                     continue
-                elif shader.inputs[0].links[0].from_node == node:
-                    texture_list.append(node)
+                elif shader.inputs[0].links:
+                    if shader.inputs[0].links[0].from_node == node:
+                        texture_list.append(node)
             
             for i, texture_node in enumerate(texture_list):
                 if texture_node is None:
@@ -1420,18 +1420,18 @@ class BlenderObjectToGeometry(object):
             data["DiffuseShader"] = "LAMBERT"
             data["SpecularShader"] = "COOKTORR"
             data["TextureSlots"] = {}
-            
-            # Textures
-            # We're only writing a single diffuse texture that's required by OpenMW, but the logic is from a more
-            # general system that was already present in the exporter and works with the rest of the code.
+            # We're only writing a single diffuse texture that's required by OpenMW,
+            # but the logic is from a more general system that was already present in
+            # the exporter and works with the rest of the code.
             texture_list = []
             for node in mat_source.node_tree.nodes:
                 if node.type != "TEX_IMAGE":
                     continue
                 elif not node.image:
                     continue
-                elif shader.inputs[0].links[0].from_node == node:
-                    texture_list.append(node)
+                elif shader.inputs[0].links:
+                    if shader.inputs[0].links[0].from_node == node:
+                        texture_list.append(node)
             
             for i, texture_node in enumerate(texture_list):
                 if texture_node is None:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1335,6 +1335,8 @@ class BlenderObjectToGeometry(object):
         # otherwise fall back to a generic material. We assume users are careful enough
         # to only include a single shader node in the material node graph as we don't
         # support anything else anyway.
+        if not mat_source.node_tree:
+            pass
         if not mat_source.node_tree.nodes:
             pass
         else:
@@ -1625,14 +1627,18 @@ class BlenderObjectToGeometry(object):
                 vcolors = tuple()
             
             #Get UV coordinates of the current vertex
-            # DISABLE FOR NOW
             #========================================
             #texcoords = [tuple(truncateVector(list(uv.data[faceindex].uv[facevertexindex])))
-                         #for uv in mesh.uv_layers]
                          #for uv in mesh.tessface_uv_textures] 2.79
             
-            #Of currently handled face, return vertices and their info and some shit.
-            return (face.vertices[facevertexindex], tuple(truncateVector(normal)), None, vcolors)
+            texcoords = []
+            # we are inputing face corners of this face, but we need to get the index of this face 
+            # corner within the mesh
+            loop = mesh.polygons[faceindex].loop_indices[facevertexindex]  
+            
+            for uv in mesh.uv_layers:
+                texcoords.append(tuple(truncateVector(list(uv.data[loop].uv))))
+
             return (face.vertices[facevertexindex], tuple(truncateVector(normal)), tuple(texcoords), vcolors)
 
         # Do stuff on all faces of a mesh
@@ -1673,11 +1679,13 @@ class BlenderObjectToGeometry(object):
                     osg_normals.getArray().append(key[1])
                     osg_vertexes.getArray().append(list(mesh.vertices[vert_index].co))
                     
-                    # DISABLED FOR NOW
                     # beware this enumerate, order can be different ?
-                    #for idx, uv in enumerate(mesh.uv_layers):
                     #for idx, uv in enumerate(mesh.tessface_uv_textures): 2.79
                         #osg_uvs.setdefault(uv.name, TexCoordArray()).getArray().append(key[2][idx])
+                    
+                    for idx, uv_layer in enumerate(mesh.uv_layers):
+                        osg_uvs.setdefault(uv_layer.name, TexCoordArray()).getArray().append(key[2][idx])
+                        print(key[2])
 
                     if vertex_colors:
                         col = key[len(key) - 1]

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -331,11 +331,12 @@ class Export(object):
         def parseLight(blender_light):
             matrix = getDeltaMatrixFrom(blender_object.parent, blender_object)
             osg_object = MatrixTransform()
-            osg_object.setName(blender_object.name)
-            
-            # When scaling the exported result, we want to only multiply location values of objects
-            mtx_util = Matrix([[0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,self.config.scale_factor-1]])
-            osg_object.matrix = (matrix * self.config.scale_factor).normalized() - mtx_util
+            osg_object.setName(blender_object.name)            
+            osg_object.matrix = matrix
+            # When scaling the exported result, we want to multiply only object's location values
+            osg_object.matrix[0][3] *= self.config.scale_factor
+            osg_object.matrix[1][3] *= self.config.scale_factor
+            osg_object.matrix[2][3] *= self.config.scale_factor
             
             lightItem = self.createLight(blender_object)
             self.createAnimationsObject(osg_object, blender_object, self.config,
@@ -353,11 +354,12 @@ class Export(object):
             # matrix for our use.
             matrix = getDeltaMatrixFrom(blender_object.parent, blender_object)
             osg_object = MatrixTransform()
-            osg_object.setName(blender_object.name)
-            
-            # When scaling the exported result, we want to only multiply location values of objects
-            mtx_util = Matrix([[0,0,0,0], [0,0,0,0], [0,0,0,0], [0,0,0,self.config.scale_factor-1]])
-            osg_object.matrix = (matrix.copy() * self.config.scale_factor).normalized() - mtx_util
+            osg_object.setName(blender_object.name)            
+            osg_object.matrix = matrix.copy()
+            # When scaling the exported result, we want to multiply only object's location values
+            osg_object.matrix[0][3] *= self.config.scale_factor
+            osg_object.matrix[1][3] *= self.config.scale_factor
+            osg_object.matrix[2][3] *= self.config.scale_factor
 
             self.createAnimationsObject(osg_object, blender_object, self.config,
                                         createAnimationUpdate(blender_object,

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -63,9 +63,7 @@ def findMaterial(name, root):
                 return found
     return None
 
-# =============================================================
-## MAIN WRITING FUNCTIONALITY
-# =============================================================
+
 class Writer(object):
     instances = {}
     wrote_elements = {}
@@ -97,18 +95,11 @@ class Writer(object):
         return text.encode('utf-8')
 
     def writeMatrix(self, output, matrix):
-        #if bpy.app.version[0] >= 2 and bpy.app.version[1] >= 62:
         for i in range(0, 4):
             output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[0][i]),
                                                             STRFLT(matrix[1][i]),
                                                             STRFLT(matrix[2][i]),
                                                             STRFLT(matrix[3][i]))))
-        #else:
-        #for i in range(0, 4):
-        #    output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[i][0]),
-        #                                                    STRFLT(matrix[i][1]),
-        #                                                    STRFLT(matrix[i][2]),
-        #                                                    STRFLT(matrix[i][3]))))
         output.write(self.encode("$#}\n"))
 
     @staticmethod
@@ -129,7 +120,6 @@ class Writer(object):
         return obj.serialize(output)
 
 
-# Write an object - WORKS
 class Object(Writer):
     instance = 0
     
@@ -1056,7 +1046,6 @@ class DrawElements(Object):
         output.write(self.encode("$#}\n"))
 
 
-# Stuff to write geometry
 class Geometry(Object):
     def __init__(self, *args, **kwargs):
         Object.__init__(self, *args, **kwargs)
@@ -1101,38 +1090,28 @@ class Geometry(Object):
             self.stateset.write(output)
             output.write(self.encode("$#}\n"))
         
-        print("I got to serializing content but have nothing to write")
-        # Writes either quads or triangles from vertices
-        # Each line is an element and contains inddexes of vertices used
-        # ======================================
+        # Writes either quads or triangles from vertices.
+        # Each line represents an element and indexes of vertices
+        # that define that element
         if len(self.primitives):
-            print("I got to writing faces but have nothing to write")
             output.write(self.encode("$#PrimitiveSetList %d {\n" % (len(self.primitives))))
             for i in self.primitives:
                 i.indent_level = self.indent_level + 2
                 i.write(output)
             output.write(self.encode("$#}\n"))
-        # ======================================
-
         
         # Writes vertices, each line is a vertex and its coordinates
-        # =======================================================
         if self.vertexes:
-            print("I got to writing vertices but have nothing to write")
             self.vertexes.indent_level = self.indent_level + 1
             self.vertexes.write(output)
         
         # Writes normals, each line is a vertex and its normal vector
-        # ===========================================================
         if self.normals:
-            print("I got to writing normals but have nothing to write")
             self.normals.indent_level = self.indent_level + 1
             self.normals.write(output)
         
-        # Writes vertex normals, each line is a vertex and its colour
-        # ==========================================================
+        # Writes vertex colors, each line is a vertex and its RGB values
         if self.colors:
-            print("I got to writing vertex colours but have nothing to write")
             self.colors.indent_level = self.indent_level + 1
             self.colors.write(output)
 
@@ -1147,10 +1126,6 @@ class Geometry(Object):
                     emptyTexCoord.indent_level = self.indent_level + 2
                     emptyTexCoord.write(output)
             output.write(self.encode("$#}\n"))
-
-
-#  animation node ######################################
-
 
 
 # Write Bone

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -97,18 +97,18 @@ class Writer(object):
         return text.encode('utf-8')
 
     def writeMatrix(self, output, matrix):
-        if bpy.app.version[0] >= 2 and bpy.app.version[1] >= 62:
-            for i in range(0, 4):
-                output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[0][i]),
-                                                               STRFLT(matrix[1][i]),
-                                                               STRFLT(matrix[2][i]),
-                                                               STRFLT(matrix[3][i]))))
-        else:
-            for i in range(0, 4):
-                output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[i][0]),
-                                                               STRFLT(matrix[i][1]),
-                                                               STRFLT(matrix[i][2]),
-                                                               STRFLT(matrix[i][3]))))
+        #if bpy.app.version[0] >= 2 and bpy.app.version[1] >= 62:
+        for i in range(0, 4):
+            output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[0][i]),
+                                                            STRFLT(matrix[1][i]),
+                                                            STRFLT(matrix[2][i]),
+                                                            STRFLT(matrix[3][i]))))
+        #else:
+        #for i in range(0, 4):
+        #    output.write(self.encode("$##%s %s %s %s\n" % (STRFLT(matrix[i][0]),
+        #                                                    STRFLT(matrix[i][1]),
+        #                                                    STRFLT(matrix[i][2]),
+        #                                                    STRFLT(matrix[i][3]))))
         output.write(self.encode("$#}\n"))
 
     @staticmethod

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -63,7 +63,9 @@ def findMaterial(name, root):
                 return found
     return None
 
-
+# =============================================================
+## MAIN WRITING FUNCTIONALITY
+# =============================================================
 class Writer(object):
     instances = {}
     wrote_elements = {}
@@ -127,9 +129,10 @@ class Writer(object):
         return obj.serialize(output)
 
 
+# Write an object - WORKS
 class Object(Writer):
     instance = 0
-
+    
     def __init__(self, *args, **kwargs):
         Writer.__init__(self, *args)
         self.dataVariance = "UNKNOWN"
@@ -1053,6 +1056,7 @@ class DrawElements(Object):
         output.write(self.encode("$#}\n"))
 
 
+# Stuff to write geometry
 class Geometry(Object):
     def __init__(self, *args, **kwargs):
         Object.__init__(self, *args, **kwargs)
@@ -1096,21 +1100,39 @@ class Geometry(Object):
             self.stateset.indent_level = self.indent_level + 2
             self.stateset.write(output)
             output.write(self.encode("$#}\n"))
-
+        
+        print("I got to serializing content but have nothing to write")
+        # Writes either quads or triangles from vertices
+        # Each line is an element and contains inddexes of vertices used
+        # ======================================
         if len(self.primitives):
+            print("I got to writing faces but have nothing to write")
             output.write(self.encode("$#PrimitiveSetList %d {\n" % (len(self.primitives))))
             for i in self.primitives:
                 i.indent_level = self.indent_level + 2
                 i.write(output)
             output.write(self.encode("$#}\n"))
+        # ======================================
 
+        
+        # Writes vertices, each line is a vertex and its coordinates
+        # =======================================================
         if self.vertexes:
+            print("I got to writing vertices but have nothing to write")
             self.vertexes.indent_level = self.indent_level + 1
             self.vertexes.write(output)
+        
+        # Writes normals, each line is a vertex and its normal vector
+        # ===========================================================
         if self.normals:
+            print("I got to writing normals but have nothing to write")
             self.normals.indent_level = self.indent_level + 1
             self.normals.write(output)
+        
+        # Writes vertex normals, each line is a vertex and its colour
+        # ==========================================================
         if self.colors:
+            print("I got to writing vertex colours but have nothing to write")
             self.colors.indent_level = self.indent_level + 1
             self.colors.write(output)
 
@@ -1128,6 +1150,10 @@ class Geometry(Object):
 
 
 #  animation node ######################################
+
+
+
+# Write Bone
 class Bone(MatrixTransform):
     def __init__(self, skeleton=None, bone=None, parent=None, **kwargs):
         MatrixTransform.__init__(self, **kwargs)
@@ -1204,7 +1230,7 @@ class Bone(MatrixTransform):
         output.write(self.encode("$#InvBindMatrixInSkeletonSpace {\n"))
         self.writeMatrix(output, matrix)
 
-
+# Write skeleton
 class Skeleton(MatrixTransform):
     def __init__(self, name="", matrix=None):
         MatrixTransform.__init__(self)
@@ -1236,7 +1262,7 @@ class Skeleton(MatrixTransform):
         MatrixTransform.serializeContent(self, output)
         output.write(self.encode("$}\n"))
 
-
+# Write blendshapes
 class MorphGeometry(Geometry):
     def __init__(self, *args, **kwargs):
         Geometry.__init__(self, *args, **kwargs)
@@ -1267,7 +1293,7 @@ class MorphGeometry(Geometry):
                 target.write(output)
             output.write(self.encode("$#}\n"))
 
-
+#Write skeleton container
 class RigGeometry(Geometry):
     def __init__(self, *args, **kwargs):
         Geometry.__init__(self, *args, **kwargs)

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -29,7 +29,7 @@ from .osgobject import *
 
 
 # IMAGES HELPERS
-# ----------------------------
+# --------------
 def createImageFilename(texturePath, image):
     fn = bpy.path.basename(bpy.path.display_name_from_filepath(image.filepath))
 
@@ -77,7 +77,7 @@ def getImageFilesFromStateSet(stateset):
 
 
 # ARMATURE AND ANIMATION HELPERS
-# ----------------------------
+# ------------------------------
 def findBoneInHierarchy(scene, bonename):
     if scene.name == bonename and (type(scene) == type(Bone()) or type(scene) == type(Skeleton())):
         return scene
@@ -238,7 +238,7 @@ def isObjectMorphAction(action):
 
 
 # OBJECTS HELPERS
-# ------------------------------
+# ---------------
 def getDeltaMatrixFromMatrix(parent, child):
     p = parent
     bi = p.copy()
@@ -295,6 +295,5 @@ def setArmaturesPosePosition(scene, pose_position, armatures=[]):
             arm_data.pose_position = pose_position
             modified.append(armature)
     
-    bpy.context.view_layer.update() # 2.80
-    #scene.update() 2.79
+    bpy.context.view_layer.update()
     return modified

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -269,7 +269,7 @@ def unselectAllObjects():
 
 def selectObjects(object_list):
     for obj in object_list:
-        obj.select_set(False)
+        obj.select_set(True)
 
 
 def spaceSafe(bonename):

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -42,7 +42,7 @@ def createImageFilename(texturePath, image):
         name = fn[0:i]
     else:
         name = fn
-    # [BMP, IRIS, PNG, JPEG, TARGA, TARGA_RAW, AVI_JPEG, AVI_RAW, FRAMESERVER]
+    # [BMP, IRIS, PNG, JPEG, TARGA, TARGA_RAW, AVI_JPEG, AVI_RAW, FRAMESERVER, DDS]
     if image.file_format == 'PNG':
         ext = "png"
     elif image.file_format == 'HDR':
@@ -55,6 +55,8 @@ def createImageFilename(texturePath, image):
         ext = "bmp"
     elif image.file_format == 'AVI_JPEG' or image.file_format == 'AVI_RAW':
         ext = "avi"
+    elif image.filepath_raw[-3:] == 'dds':
+        ext = "dds"
     else:
         ext = "unknown"
     name = name + "." + ext

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -264,12 +264,12 @@ def isActionLinkedToObject(action, objects_name):
 
 def unselectAllObjects():
     for obj in bpy.context.selected_objects:
-        obj.select = False
+        obj.select_set(False)
 
 
 def selectObjects(object_list):
     for obj in object_list:
-        obj.select = True
+        obj.select_set(False)
 
 
 def spaceSafe(bonename):
@@ -292,6 +292,7 @@ def setArmaturesPosePosition(scene, pose_position, armatures=[]):
         if arm_data.pose_position != pose_position:
             arm_data.pose_position = pose_position
             modified.append(armature)
-
-    scene.update()
+    
+    bpy.context.view_layer.update() # 2.80
+    #scene.update() 2.79
     return modified


### PR DESCRIPTION
Enables the osgt exporter for use in Blender 2.80 and newer. Cleaned https://github.com/OpenMW/osgexport/pull/3 so it only includes 2.80-enabling commits and not the other stuff from upstream.

Currently works for static objects, no animations. The animation code is inaccessible to users and hasn't been updated. Features that aren't used are not exposed in the UI.

Notes:

- only a single collision mesh per file ( shouldn't be a problem for 99% of cases)
- no shadeless or alpha clip materials just yet
- as mentioned, no animations
- no material animations
- light objects can also be exported but OpenMW ignores those
- no particle systems (there weren't any to begin with, but we can get something to work in the future)
- the improvements take the liberty and adjust the exporter to be less OpenSceneGraph generic and instead make it OpenMW specific. This is done with as minimal changes as possible, but always with the goal in mind, to allow for the most comfortable Blender-OpenMW workflow.

**Textured materials**
![textures_materials](https://user-images.githubusercontent.com/3763179/231701666-4de47778-b495-4437-84b4-6b28c17dd3a5.jpg)

**Material setup the same as with COLLADA**
![material_setup](https://user-images.githubusercontent.com/3763179/231702328-f91dae0f-ae16-473d-9e9f-3b4455ebdeec.png)

**Custom normals**
![custom_normals](https://user-images.githubusercontent.com/3763179/231701848-8825aa64-1042-4d88-9971-6208069f377c.jpg)

**Nice UI**
![exporter_ui](https://user-images.githubusercontent.com/3763179/231702087-f477d2f3-68a6-4e2d-b7e8-8a4f18818376.png)

**Custom collision shapes**
An object with a 'Collision' modifier gets renamed and OpenMW then recognizes it.
![collisions](https://user-images.githubusercontent.com/3763179/231702639-b652b99a-40a6-44a7-a7ea-ff2560f35f48.png)
