### PR TITLE
Improve material workflow & cleanup

### DIFF
--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -951,31 +951,7 @@ class BlenderObjectToGeometry(object):
         self.mesh = kwargs.get("mesh", None)
         self.material_animations = {}
 
-    # Not used anymore as Blender 2.80 doesn't have textures tied to the material the same way.
-    #def createTexture2D(self, mtex):
-        #image_object = None
-        #try:
-            #image_object = mtex.texture.image
-        #except:
-            #image_object = None
-        #if image_object is None:
-            #Log("Warning: [[blender]] The texture {} is skipped since it has no Image".format(mtex.name))
-            #return None
-
-        #if self.unique_objects.hasTexture(mtex.texture):
-            #return self.unique_objects.getTexture(mtex.texture)
-
-        #texture = Texture2D()
-        #texture.name = mtex.texture.name
-
-        #reference texture relative to export path
-        #filename = createImageFilename(self.config.texture_prefix, image_object)
-        #texture.file = filename
-        #texture.source_image = image_object
-        #self.unique_objects.registerTexture(mtex.texture, texture)
-        #return texture
-
-    def createTexture2DFromNode(self, node): # TEXTURES DISABLED; NOT CALLED
+    def createTexture2DFromNode(self, node):
         image_object = None
         try:
             image_object = node.image
@@ -1093,117 +1069,8 @@ class BlenderObjectToGeometry(object):
             # osg_object.getOrCreateUserData().append(StringValueObject("source", "blender"))
         
         self.createStateSetMaterial(mat_source, stateset, material)
-        
-        # Disabled JSON material export
-        #if mat_source.use_nodes is True:
-            #self.createStateSetShaderNode(mat_source, stateset, material)
-        #else:
-            #self.createStateSetMaterial(mat_source, stateset, material)
 
         return stateset
-    
-    # Disabled JSON material export
-    #def createStateSetShaderNode(self, mat_source, stateset, material):
-        #"""
-        #Reads a shadernode to an osg stateset/material
-        #"""
-        #if self.config.json_shaders:
-            #self.createStateSetShaderNodeJSON(mat_source, stateset, material)
-        #else:
-            #self.createStateSetShaderNodeUserData(mat_source, material)
-
-    # Disabled JSON material export
-    #def createStateSetShaderNodeJSON(self, mat_source, stateset, material):
-        #"""
-        #Serializes a blender shadernode into a JSON object
-        #"""
-        #source_tree = mat_source.node_tree
-
-        #def createSocket(source_socket):
-            #socket = {
-                #"name": source_socket.name,
-                #"type": source_socket.type,
-                #"enabled": source_socket.enabled,
-                #"links": []
-            #}
-            #for source_link in source_socket.links:
-                #socket['links'].append({
-                    #"from_node": source_link.from_node.name,
-                    #"from_socket": source_link.from_socket.name,
-                    #"to_node": source_link.to_node.name,
-                    #"to_socket": source_link.to_socket.name
-                #})
-
-            #if hasattr(source_socket, 'default_value'):
-                #value = source_socket.default_value
-                #if isinstance(value, Vector) or str(type(value)) \
-                   #in ["<class 'bpy_prop_array'>", "<class 'mathutils.Color'>"]:
-                    #socket['default_value'] = [v for v in value]
-                #else:
-                    #socket['default_value'] = value
-
-            #return socket
-
-        #tree = {
-            #"nodes": {}
-        #}
-        #texture_slot_id = 0
-        #for source_node in source_tree.nodes:
-            #node = {
-                #"name": source_node.name,
-                #"type": source_node.type,
-                #"inputs": [createSocket(source_input) for source_input in source_node.inputs],
-                #"outputs": [createSocket(source_output) for source_output in source_node.outputs]
-            #}
-
-            #if source_node.type == "TEX_IMAGE" and source_node.image is not None:
-                #node["texture_mapping"] = {
-                    #"mapping": source_node.texture_mapping.mapping
-                #}
-                #node["image"] = {
-                    #"filepath_raw": source_node.image.filepath_raw,
-                    #"use_alpha": source_node.image.use_alpha,
-                    #"colorspace": source_node.image.colorspace_settings.name,
-                    #"channels": source_node.image.channels
-                #}
-                #node["texture_slot"] = texture_slot_id
-
-                #texture = self.createTexture2DFromNode(source_node)
-                #stateset.texture_attributes.setdefault(texture_slot_id, []).append(texture)
-                #texture_slot_id += 1
-
-            #tree['nodes'][source_node.name] = node
-
-        #safely delete unused nodes
-        #nodes = tree['nodes']
-        #for name in list(nodes.keys()):
-            #node = nodes[name]
-            #if all(map(lambda socket: len(socket['links']) == 0, node['inputs'])) and \
-               #all(map(lambda socket: len(socket['links']) == 0, node['outputs'])):
-                #del nodes[name]
-
-        #material.getOrCreateUserData().append(StringValueObject("NodeTree", json.dumps(tree)))
-
-    #def createStateSetShaderNodeUserData(self, mat_source, material): # NODE STUFF REGULAR (DISABLED)
-        #"""
-        #reads a shadernode to a basic material
-        #"""
-        #userData = material.getOrCreateUserData()
-        #for node in mat_source.node_tree.nodes:
-            #if node.type == "BSDF_DIFFUSE":
-                #if not node.inputs["Color"].is_linked:
-                    #value = node.inputs["Color"].default_value
-                    #userData.append(StringValueObject("DiffuseColor",
-                                                      #"[{}, {}, {}]".format(value[0],
-                                                                            #value[1],
-                                                                            #value[2])))
-            #elif node.type == "BSDF_GLOSSY":
-                #if not node.inputs["Color"].is_linked:
-                    #value = node.inputs["Color"].default_value
-                    #userData.append(StringValueObject("SpecularColor",
-                                                      #"[{}, {}, {}]".format(value[0],
-                                                                            #value[1],
-                                                                            #value[2])))
 
     def createStateSetMaterial(self, mat_source, stateset, material):
         """
@@ -1284,20 +1151,8 @@ class BlenderObjectToGeometry(object):
             material.emission = (0.0, 0.0, 0.0, 1.0)       
             material.shininess = 0
 
-        # if alpha not 1 then we set the blending mode on
-        #if DEBUG:
-            #Log("state material alpha {}".format(alpha))
-        #if alpha != 1.0:
-        #    stateset.modes["GL_BLEND"] = "ON"
-
         material_data = self.createStateSetMaterialData(mat_source, stateset)
         self.createStateSetMaterialUserData(material_data, stateset, material)
-        
-        # Disabled JSON material export
-        #if self.config.json_materials:
-            #self.createStateSetMaterialJson(material_data, stateset)
-        #else:
-            #self.createStateSetMaterialUserData(material_data, stateset, material)
 
         return stateset
 
@@ -1306,14 +1161,6 @@ class BlenderObjectToGeometry(object):
         Reads a blender material into an osg stateset/material json userdata
         Writes the separate osg::StringValueObject entries of a material for each item included below
         """
-        
-        #def premultAlpha(slot, data):
-            #if slot.texture and slot.texture.image:
-                #data["UsePremultiplyAlpha"] = slot.texture.image.alpha_mode == 'PREMULT'
-
-        #def useAlpha(slot, data):
-            #if slot.texture and slot.texture.use_alpha:
-                #data["UseAlpha"] = True
                 
         data = {}
         shader = None
@@ -1418,23 +1265,9 @@ class BlenderObjectToGeometry(object):
                 data_texture_slot = data["TextureSlots"].setdefault(i, {})
                 data_texture_slot["BlendType"] = "MIX"
                 stateset.texture_attributes.setdefault(0, []).append(texture)
-                data_texture_slot["DiffuseColor"] = 1.0       
-
-        #try:
-            #if t.source_image.getDepth() > 24:  # there is an alpha
-                #stateset.modes["GL_BLEND"] = "ON"
-        #except:
-            #pass
+                data_texture_slot["DiffuseColor"] = 1.0
 
         return data
-    
-    # Disabled JSON material export
-    #def createStateSetMaterialJson(self, data, stateset):
-        """
-        Serialize blender material data into stateset as a JSON user data
-        """
-        #stateset.getOrCreateUserData().append(StringValueObject("BlenderMaterial",
-                                                                #json.dumps(data)))
 
     def createStateSetMaterialUserData(self, data, stateset, material):
         """

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -612,8 +612,6 @@ class Export(object):
         self.root = Group()
         self.root.setName("Root")
         self.root.children = self.items
-        # CUSTOM USER DATA - scene roon node
-        #self.root.getOrCreateUserData().append(StringValueObject("source", "blender"))
         if len(self.animations) > 0:
             animation_manager = BasicAnimationManager()
             animation_manager.animations = self.animations
@@ -883,8 +881,6 @@ class BlenderLightToLightSource(object):
         osg_light.specular = (energy, energy, energy, 1.0)  # osg_light.diffuse
         osg_light.specular = (0, 0, 0, 1.0)
         
-        # CUSTOM USER DATA - light
-        # osg_light.getOrCreateUserData().append(StringValueObject("source", "blender")) # User data - light
         osg_light.getOrCreateUserData().append(StringValueObject("Energy", str(energy)))
         osg_light.getOrCreateUserData().append(StringValueObject("Color", "[{}, {}, {}]".format(self.light.color[0],
                                                                                             self.light.color[1],
@@ -1079,8 +1075,6 @@ class BlenderObjectToGeometry(object):
         for osg_object in (stateset, material):
             osg_object.dataVariance = "STATIC"
             osg_object.setName(mat_source.name)
-            # CUSTOM USER DATA - stateset
-            # osg_object.getOrCreateUserData().append(StringValueObject("source", "blender"))
         
         self.createStateSetMaterial(mat_source, stateset)
 
@@ -1257,19 +1251,6 @@ class BlenderObjectToGeometry(object):
                     data_texture_slot["BlendType"] = "MIX"
                     stateset.texture_attributes.setdefault(0, []).append(texture)
                     data_texture_slot["DiffuseColor"] = 1.0
-        
-        # CUSTOM USER DATA - material
-        #data["DiffuseIntensity"] = 1.0
-        #data["DiffuseColor"] = shader.inputs[0].default_value[:3]
-        #data["SpecularIntensity"] = 1.0
-        #data["SpecularColor"] = (1.0, 1.0, 1.0, 1.0)
-        #data["SpecularHardness"] = 50
-        #data["Shadeless"] = True
-        #data["Emit"] = 0.0
-        #data["Ambient"] = 0.0
-        #data["Translucency"] = 0.0
-        #data["DiffuseShader"] = "LAMBERT"
-        #data["SpecularShader"] = "COOKTORR"
 
         return data
 
@@ -1286,21 +1267,8 @@ class BlenderObjectToGeometry(object):
             elif isinstance(value, str):
                 return value
             return None
-        
-        # CUSTOM USER DATA - material
-        #userData = material.getOrCreateUserData()
-        #for key, value in data.items():
-        #    userdata = toUserData(value)
-        #    if userdata is not None:
-        #        userData.append(StringValueObject(key, userdata))
 
         slot_name = lambda index, label: "{:02}_{}".format(index, label)
-        
-        # CUSTOM USER DATA - texture
-        #userData = stateset.getOrCreateUserData()
-        #for index, slot in data["TextureSlots"].items():
-        #    for key, value in slot.items():
-        #        userData.append(StringValueObject(slot_name(index, key), toUserData(value)))
 
     def parseMorphTargets(self, obj, geometry, morph_vertex_map, material_index):
         ''' Create morph targets '''

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -612,7 +612,8 @@ class Export(object):
         self.root = Group()
         self.root.setName("Root")
         self.root.children = self.items
-        self.root.getOrCreateUserData().append(StringValueObject("source", "blender"))
+        # CUSTOM USER DATA - scene roon node
+        #self.root.getOrCreateUserData().append(StringValueObject("source", "blender"))
         if len(self.animations) > 0:
             animation_manager = BasicAnimationManager()
             animation_manager.animations = self.animations
@@ -881,8 +882,9 @@ class BlenderLightToLightSource(object):
 
         osg_light.specular = (energy, energy, energy, 1.0)  # osg_light.diffuse
         osg_light.specular = (0, 0, 0, 1.0)
-
-        osg_light.getOrCreateUserData().append(StringValueObject("source", "blender"))
+        
+        # CUSTOM USER DATA - light
+        # osg_light.getOrCreateUserData().append(StringValueObject("source", "blender")) # User data - light
         osg_light.getOrCreateUserData().append(StringValueObject("Energy", str(energy)))
         osg_light.getOrCreateUserData().append(StringValueObject("Color", "[{}, {}, {}]".format(self.light.color[0],
                                                                                             self.light.color[1],
@@ -1087,7 +1089,8 @@ class BlenderObjectToGeometry(object):
         for osg_object in (stateset, material):
             osg_object.dataVariance = "STATIC"
             osg_object.setName(mat_source.name)
-            osg_object.getOrCreateUserData().append(StringValueObject("source", "blender"))
+            # CUSTOM USER DATA - stateset
+            # osg_object.getOrCreateUserData().append(StringValueObject("source", "blender"))
         
         self.createStateSetMaterial(mat_source, stateset, material)
         
@@ -1215,7 +1218,7 @@ class BlenderObjectToGeometry(object):
         anim = createAnimationMaterialAndSetCallback(material, mat_source, self.config, self.unique_objects)
         if anim:
             for osg_object in (stateset, material):
-                stateset.dataVariance = "DYNAMIC";
+                stateset.dataVariance = "DYNAMIC"
             self.material_animations[anim.name] = anim
         
         shader = None
@@ -1446,20 +1449,21 @@ class BlenderObjectToGeometry(object):
             elif isinstance(value, str):
                 return value
             return None
-
-        userData = material.getOrCreateUserData()
-
-        for key, value in data.items():
-            userdata = toUserData(value)
-            if userdata is not None:
-                userData.append(StringValueObject(key, userdata))
+        
+        # CUSTOM USER DATA - material
+        #userData = material.getOrCreateUserData()
+        #for key, value in data.items():
+        #    userdata = toUserData(value)
+        #    if userdata is not None:
+        #        userData.append(StringValueObject(key, userdata))
 
         slot_name = lambda index, label: "{:02}_{}".format(index, label)
         
-        userData = stateset.getOrCreateUserData()
-        for index, slot in data["TextureSlots"].items():
-            for key, value in slot.items():
-                userData.append(StringValueObject(slot_name(index, key), toUserData(value)))
+        # CUSTOM USER DATA - texture
+        #userData = stateset.getOrCreateUserData()
+        #for index, slot in data["TextureSlots"].items():
+        #    for key, value in slot.items():
+        #        userData.append(StringValueObject(slot_name(index, key), toUserData(value)))
 
     def parseMorphTargets(self, obj, geometry, morph_vertex_map, material_index):
         ''' Create morph targets '''

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -945,7 +945,7 @@ class StateSet(Object):
             output.write(self.encode("$#TextureAttributeList %d {\n" % len(self.texture_attributes[0])))
             for i in range(0, max_texture_used + 1):
                 if i in self.texture_attributes:
-                    texture_attributes = self.texture_attributes.get(i)
+                    texture_attributes = self.texture_attributes.get(i, [])
                     for a in texture_attributes:
                         if a is not None:
                             output.write(self.encode("$##Data 1 {\n"))

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -817,6 +817,50 @@ class Material(StateAttribute):
                                                                           STRFLT(self.shininess))))
 
 
+class BlendFunc(StateAttribute):
+    def __init__(self, *args, **kwargs):
+        StateAttribute.__init__(self, *args, **kwargs)
+        self.source_rgb = "SRC_ALPHA"
+        self.source_alpha = "SRC_ALPHA"
+        self.destination_rgb = "ONE_MINUS_SRC_ALPHA"
+        self.destination_alpha = "ONE_MINUS_SRC_ALPHA"
+    
+    def className(self):
+        return "BlendFunc"
+
+    def serialize(self, output):
+        output.write(self.encode("$%s {\n" % (self.getNameSpaceClass())))
+        self.serializeContent(output)
+        output.write(self.encode("$}\n"))
+
+    def serializeContent(self, output):
+        StateAttribute.serializeContent(self, output)
+        output.write(self.encode("$#SourceRGB %s\n" % self.source_rgb)) 
+        output.write(self.encode("$#SourceAlpha %s\n" % self.source_alpha)) 
+        output.write(self.encode("$#DestinationRGB %s\n" % self.destination_rgb)) 
+        output.write(self.encode("$#DestinationAlpha %s\n" % self.destination_alpha))
+
+
+class AlphaFunc(StateAttribute):
+    def __init__(self, *args, **kwargs):
+        StateAttribute.__init__(self, *args, **kwargs)
+        self.function = "GEQUAL"
+        self.reference_value = 0.5
+    
+    def className(self):
+        return "AlphaFunc"
+
+    def serialize(self, output):
+        output.write(self.encode("$%s {\n" % (self.getNameSpaceClass())))
+        self.serializeContent(output)
+        output.write(self.encode("$}\n"))
+
+    def serializeContent(self, output):
+        StateAttribute.serializeContent(self, output)
+        output.write(self.encode("$#Function %s\n" % self.function)) 
+        output.write(self.encode("$#ReferenceValue %s\n" % self.reference_value)) 
+
+
 class LightModel(StateAttribute):
     def __init__(self, *args, **kwargs):
         StateAttribute.__init__(self, *args, **kwargs)
@@ -878,6 +922,7 @@ class StateSet(Object):
             output.write(self.encode("$#}\n"))
 
         if len(self.attributes) > 0:
+            print("yo we got yo" + str(self.attributes))
             output.write(self.encode("$#AttributeList %d {\n" % (len(self.attributes))))
             for i in self.attributes:
                 if i is not None:

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -943,17 +943,17 @@ class StateSet(Object):
                     output.write(self.encode("$##Data 0\n"))
             output.write(self.encode("$#}\n"))
 
-            output.write(self.encode("$#TextureAttributeList %d {\n" % (1 + max_texture_used)))
+            output.write(self.encode("$#TextureAttributeList %d {\n" % len(self.texture_attributes[0])))
             for i in range(0, max_texture_used + 1):
                 if i in self.texture_attributes:
-                    attributes = self.texture_attributes.get(i)
-                    output.write(self.encode("$##Data %d {\n" % len(attributes)))
-                    for a in attributes:
+                    texture_attributes = self.texture_attributes.get(i)
+                    for a in texture_attributes:
                         if a is not None:
+                            output.write(self.encode("$##Data 1 {\n"))
                             a.indent_level = self.indent_level + 3
                             a.write(output)
                         output.write(self.encode("$###Value OFF\n"))
-                    output.write(self.encode("$##}\n"))
+                        output.write(self.encode("$##}\n"))
                 else:
                     output.write(self.encode("$##Data 0\n"))
             output.write(self.encode("$#}\n"))

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -922,7 +922,6 @@ class StateSet(Object):
             output.write(self.encode("$#}\n"))
 
         if len(self.attributes) > 0:
-            print("yo we got yo" + str(self.attributes))
             output.write(self.encode("$#AttributeList %d {\n" % (len(self.attributes))))
             for i in self.attributes:
                 if i is not None:


### PR DESCRIPTION
The following changes have been made.

**1. We can now export various materials based on the setup in Blender.**

Specular BSDF + opaque blend option in Blender -> regular, opaque material

![regular_opaque](https://user-images.githubusercontent.com/3763179/235000018-7c7b15a4-63aa-408d-9ef8-8123608e7c87.jpg)
-----

Specular BSDF + alpha blend option -> transparent material

![regular_alpha_blend](https://user-images.githubusercontent.com/3763179/235000125-bc4b7950-79df-448a-b8e9-aadc19f5978f.jpg)
-----

Specular BSDF + alpha clip option -> alpha test material

![regular_alpha_test](https://user-images.githubusercontent.com/3763179/235000299-123b41a1-0d4a-4099-90fe-c28baacb544f.jpg)
-----

Emissive + opaque -> shadeless material

![emissive_opaque](https://user-images.githubusercontent.com/3763179/235000557-de9a3ed6-a6cb-4934-ac62-19a430d1ddc0.jpg)
-----

Emissive + alpha blend -> alpha additive material

![emissive_alpha_blend](https://user-images.githubusercontent.com/3763179/235000768-4794a77b-b007-445c-bce3-61e181f1a367.jpg)
-----

Emissive + alpha clip -> shadeless alpha test material

![emissive_alpha_test](https://user-images.githubusercontent.com/3763179/235001270-776179d6-55df-478c-9d32-f9a3fa3f0527.jpg)
-----

**2. Texture export has been adjusted so OpenMW recognizes multiple textures included in a file**
Previously OpenMW only recognized a single texture even when many were included in the exported file. This for example allows exporting objects with diffuse + emissive textures. Supported are diffuse, specular, normal, emissive textures. 

![regular_emissive_textures](https://user-images.githubusercontent.com/3763179/235001700-7ec9781a-a91b-42a7-a870-b930b73db9be.jpg)

**3. Commented out writing custom material properties**
The script used to write custom material properties that we don't need and OpenMW doesn't use or recognize anyway. Commented out but left in case we might need it in the future (very unlikely but who knows)

**4. Cleanup and remove unused code.**
Mainly remnants of material JSON export code, and old texture slot export functionality. Neither are used or needed by OpenMW and don't translate directly to 2.80 anyway.










