### PR TITLE
Re-enable animation exporting

### DIFF
--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -625,7 +625,7 @@ classes = (
     OSGT_PT_export_transform,
     OSGT_PT_export_geometry,
     #OSGT_PT_export_material,
-    #OSGT_PT_export_animation,
+    OSGT_PT_export_animation,
     OSGT_PT_export_extra,
     OSGT_PT_export_postprocess,
 )

--- a/exporter/osg/osgbake.py
+++ b/exporter/osg/osgbake.py
@@ -186,7 +186,7 @@ def bakeAction(blender_object,
             pbone.bone.use_inherit_rotation = True
             if do_visual_keying:
                 # Get the final transform of the bone in its own local space...
-                matrix[name] = blender_object.convert_space(pbone, pbone.matrix, 'POSE', 'LOCAL')
+                matrix[name] = blender_object.convert_space(pose_bone=pbone, matrix=pbone.matrix, from_space='POSE', to_space='LOCAL')
             else:
                 matrix[name] = pbone.matrix_basis.copy()
 
@@ -226,7 +226,7 @@ def bakeAction(blender_object,
     pose_info = []
     obj_info = []
 
-    options = {'INSERTKEY_NEEDED'}
+    key_options = {'INSERTKEY_NEEDED'}
 
     frame_range = range(frame_start, frame_end + 1, frame_step)
 
@@ -273,13 +273,13 @@ def bakeAction(blender_object,
             for (f, matrix) in zip(frame_range, pose_info):
                 pbone.matrix_basis = matrix[name].copy()
 
-                pbone.keyframe_insert("location", -1, f, name, options)
+                pbone.keyframe_insert("location", index=-1, frame=f, group=name, options=key_options)
 
                 rotation_mode = pbone.rotation_mode
                 if rotation_mode == 'QUATERNION':
-                    pbone.keyframe_insert("rotation_quaternion", -1, f, name, options)
+                    pbone.keyframe_insert("rotation_quaternion", index=-1, frame=f, group=name, options=key_options)
                 elif rotation_mode == 'AXIS_ANGLE':
-                    pbone.keyframe_insert("rotation_axis_angle", -1, f, name, options)
+                    pbone.keyframe_insert("rotation_axis_angle", index=-1, frame=f, group=name, options=key_options)
                 else:  # euler, XYZ, ZXY etc
                     if euler_prev is not None:
                         euler = pbone.rotation_euler.copy()
@@ -289,9 +289,9 @@ def bakeAction(blender_object,
                         del euler
                     else:
                         euler_prev = pbone.rotation_euler.copy()
-                    pbone.keyframe_insert("rotation_euler", -1, f, name, options)
+                    pbone.keyframe_insert("rotation_euler", index=-1, frame=f, group=name, options=key_options)
 
-                pbone.keyframe_insert("scale", -1, f, name, options)
+                pbone.keyframe_insert("scale", index=-1, frame=f, group=name, options=key_options)
 
             # restore rotation mode
             pbone.rotation_mode = rotation_mode_backup
@@ -331,13 +331,13 @@ def bakeAction(blender_object,
                     # so we need to take to take bone's length into account
                     blender_object.location += bone_correction
 
-            blender_object.keyframe_insert("location", -1, f, name, options)
+            blender_object.keyframe_insert("location", index=-1, frame=f, group=name, options=key_options)
 
             rotation_mode = blender_object.rotation_mode
             if rotation_mode == 'QUATERNION':
-                blender_object.keyframe_insert("rotation_quaternion", -1, f, name, options)
+                blender_object.keyframe_insert("rotation_quaternion", index=-1, frame=f, group=name, options=key_options)
             elif rotation_mode == 'AXIS_ANGLE':
-                blender_object.keyframe_insert("rotation_axis_angle", -1, f, name, options)
+                blender_object.keyframe_insert("rotation_axis_angle", index=-1, frame=f, group=name, options=key_options)
             else:  # euler, XYZ, ZXY etc
                 if euler_prev is not None:
                     euler = blender_object.rotation_euler.copy()
@@ -347,9 +347,9 @@ def bakeAction(blender_object,
                     del euler
                 else:
                     euler_prev = blender_object.rotation_euler.copy()
-                blender_object.keyframe_insert("rotation_euler", -1, f, name, options)
+                blender_object.keyframe_insert("rotation_euler", index=-1, frame=f, group=name, options=key_options)
 
-            blender_object.keyframe_insert("scale", -1, f, name, options)
+            blender_object.keyframe_insert("scale", index=-1, frame=f, group=name, options=key_options)
 
         # restore rotation mode
         blender_object.rotation_mode = rotation_mode_backup

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1762,7 +1762,7 @@ class BlenderAnimationToAnimation(object):
 
             value = [realtime]
             for fcurve in fcurves:
-                if fcurve.data_path == "location":
+                if fcurve.data_path.endswith("location"):
                     # When scaling the exported result, we want to multiply only object's location values
                     value.append(fcurve.evaluate(time) * self.config.scale_factor)
                 else:

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -1204,7 +1204,7 @@ class Bone(MatrixTransform):
             else:
                 parent_matrix = self.bone.parent.matrix_local.copy()
             # This matrix is not always invertible
-            bone_matrix = parent_matrix.inverted_safe() * bone_matrix
+            bone_matrix = parent_matrix.inverted_safe() @ bone_matrix
 
         # add bind matrix in localspace callback
         update_callback.stacked_transforms.append(StackedMatrixElement(name="bindmatrix", matrix=bone_matrix))

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -1183,7 +1183,7 @@ class Bone(MatrixTransform):
         # self.inverse_bind_matrix = Matrix().to_4x4().identity()
         self.bone_inv_bind_matrix_skeleton = Matrix().to_4x4()
 
-    def buildBoneChildren(self, use_pose=False):
+    def buildBoneChildren(self, use_pose=False, scale_factor=1.0):
         if self.skeleton is None or self.bone is None:
             return
 
@@ -1196,7 +1196,10 @@ class Bone(MatrixTransform):
         if use_pose:
             bone_matrix = self.skeleton.pose.bones[self.bone.name].matrix.copy()
         else:
-            bone_matrix = self.bone.matrix_local.copy()
+            bone_matrix = self.bone.matrix_local.copy()        
+        
+        # When scaling the exported result, we want to multiply only bone's location values
+        bone_matrix.translation *= scale_factor
 
         if self.parent:
             if use_pose:
@@ -1213,13 +1216,15 @@ class Bone(MatrixTransform):
         update_callback.stacked_transforms.append(StackedScaleElement())
 
         self.bone_inv_bind_matrix_skeleton = self.bone.matrix_local.copy().inverted()
+        self.bone_inv_bind_matrix_skeleton.translation *= scale_factor
+        
         if not self.bone.children:
             return
 
         for boneChild in self.bone.children:
             b = Bone(self.skeleton, boneChild, self)
             self.children.append(b)
-            b.buildBoneChildren(use_pose)
+            b.buildBoneChildren(use_pose, scale_factor)
 
     def getMatrixInArmatureSpace(self):
         return self.bone.matrix_local

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -1198,8 +1198,6 @@ class Bone(MatrixTransform):
         else:
             bone_matrix = self.bone.matrix_local.copy()        
         
-        # When scaling the exported result, we want to multiply only bone's location values
-        bone_matrix.translation *= scale_factor
 
         if self.parent:
             if use_pose:
@@ -1209,6 +1207,9 @@ class Bone(MatrixTransform):
             # This matrix is not always invertible
             bone_matrix = parent_matrix.inverted_safe() @ bone_matrix
 
+        # When scaling the exported result, we want to multiply only bone's location values
+        bone_matrix.translation *= scale_factor
+        
         # add bind matrix in localspace callback
         update_callback.stacked_transforms.append(StackedMatrixElement(name="bindmatrix", matrix=bone_matrix))
         update_callback.stacked_transforms.append(StackedTranslateElement())

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -92,14 +92,6 @@ def findBoneInHierarchy(scene, bonename):
     return None
 
 
-def getRootBonesList(armature):
-    bones = []
-    for bone in armature.bones:
-        if bone.parent is None:
-            bones.append(bone)
-    return bones
-
-
 def truncateFloat(value, digit=5):
     if math.isnan(value):
         return 0


### PR DESCRIPTION
Works for object and armature animations. This MR adds the following:

1. Updating 2.79 stuff to work in 2.80+ (function arguments and the way matrices are multiplied)
2. Hooking up the scaling factor to rigs and animations
3. Expose animation exporting in the exporter's UI

Other workflow improvements will come in the future. I figured it's better to do a few smaller MRs than a single big one.  