### PR TITLE
Add an option to only export deform bones of an armature

### DIFF
--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -242,9 +242,15 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         )
     
     ARMATURE_REST : BoolProperty(
-        name="Export armature in REST pose",
-        description="Static armatures are exported in REST mode instead of POSE mode",
+        name="Force REST pose",
+        description="Export armatures in REST mode instead of POSE mode",
         default=False
+        )
+    
+    ARMATURE_DEFORM_ONLY : BoolProperty(
+        name="Only Deform Bones",
+        description=("Only export bones which are enabled to deform geometry"),
+        default=True,
         )
     
     OSGCONV_TO_IVE : BoolProperty(
@@ -339,6 +345,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.BAKE_CONSTRAINTS = self.config.bake_constraints
         self.BAKE_FRAME_STEP = self.config.bake_frame_step
         self.ARMATURE_REST = self.config.arm_rest
+        self.ARMATURE_DEFORM_ONLY = self.config.arm_deform_only
         self.OSGCONV_TO_IVE = self.config.osgconv_to_ive
         self.OSGCONV_EMBED_TEXTURES = self.config.osgconv_embed_textures
         self.OSGCONV_PATH = self.config.osgconv_path
@@ -380,6 +387,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.bake_constraints = self.BAKE_CONSTRAINTS
         self.config.bake_frame_step = self.BAKE_FRAME_STEP
         self.config.arm_rest = self.ARMATURE_REST
+        self.config.arm_deform_only = self.ARMATURE_DEFORM_ONLY
         self.config.osgconv_to_ive = self.OSGCONV_TO_IVE
         self.config.osgconv_path = self.OSGCONV_PATH
         self.config.run_viewer = self.RUN_VIEWER
@@ -500,6 +508,33 @@ class OSGT_PT_export_geometry(bpy.types.Panel):
         col.prop(operator, 'APPLYMODIFIERS')
 
 
+class OSGT_PT_export_armature(bpy.types.Panel):
+    bl_space_type = 'FILE_BROWSER'
+    bl_region_type = 'TOOL_PROPS'
+    bl_label = "Armature"
+    bl_parent_id = "FILE_PT_operator"
+    bl_options = {'DEFAULT_CLOSED'}
+    
+    @classmethod
+    def poll(cls, context):
+        sfile = context.space_data
+        operator = sfile.active_operator
+            
+        return operator.bl_idname == "OSG_OT_export"
+    
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        
+        sfile = context.space_data
+        operator = sfile.active_operator
+        
+        col = layout.column(align = True)
+        col.prop(operator, 'ARMATURE_DEFORM_ONLY')
+        col.prop(operator, 'ARMATURE_REST')
+
+
 class OSGT_PT_export_animation(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
     bl_region_type = 'TOOL_PROPS'
@@ -534,7 +569,6 @@ class OSGT_PT_export_animation(bpy.types.Panel):
         col.prop(operator, 'BAKE_ALL')
         col.prop(operator, 'BAKE_CONSTRAINTS')
         col.prop(operator, 'USE_QUATERNIONS')
-        col.prop(operator, 'ARMATURE_REST')
 
 
 class OSGT_PT_export_postprocess(bpy.types.Panel):
@@ -624,6 +658,7 @@ classes = (
     OSGT_PT_export_include,
     OSGT_PT_export_transform,
     OSGT_PT_export_geometry,
+    OSGT_PT_export_armature,
     #OSGT_PT_export_material,
     OSGT_PT_export_animation,
     OSGT_PT_export_extra,

--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -249,7 +249,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
     
     ARMATURE_DEFORM_ONLY : BoolProperty(
         name="Only Deform Bones",
-        description=("Only export bones which are enabled to deform geometry"),
+        description="Only export bones which are enabled to deform geometry",
         default=True,
         )
     

--- a/exporter/osg/osgbake.py
+++ b/exporter/osg/osgbake.py
@@ -259,7 +259,7 @@ def bakeAction(blender_object,
         for name, pbone in blender_object.pose.bones.items():
             if only_selected and not pbone.bone.select:
                 continue
-            if deform_only and not isDeform(blender_object.data.bones[pbone.name]):
+            if bake_deform_only and not isDeform(blender_object.data.bones[pbone.name]):
                 continue
             # Quaternions are forced for bones
             rotation_mode_backup = pbone.rotation_mode

--- a/exporter/osg/osgbake.py
+++ b/exporter/osg/osgbake.py
@@ -19,6 +19,7 @@
 # <pep8-80 compliant>
 import bpy
 import bisect
+from mathutils import Vector, Matrix
 from .osgutils import *
 
 
@@ -141,7 +142,7 @@ def bakeAction(blender_object,
                do_parents_clear=False,
                do_clean=False,
                action=None,
-               deform_only=False,
+               bake_deform_only=False,
                ):
 
     """
@@ -252,12 +253,7 @@ def bakeAction(blender_object,
 
     # -------------------------------------------------------------------------
     # Apply transformations to action
-    def isDeform(bone):
-        if bone.use_deform:
-            return True
-        for b in bone.children_recursive:
-            if b.use_deform:
-                return True
+
     # pose
     if do_pose:
         for name, pbone in blender_object.pose.bones.items():
@@ -407,7 +403,7 @@ def bakeAnimation(scene, start, end, frame_step, blender_object, has_action=Fals
                               use_quaternions=use_quaternions,  # use_quaternions,
                               # visual keying bakes in worldspace, but here we want it local since we keep parenting
                               do_visual_keying=do_visual_keying,
-                              deform_only=deform_only,
+                              bake_deform_only=deform_only,
                               )
 
     # restore original action and armatures' pose position

--- a/exporter/osg/osgconf.py
+++ b/exporter/osg/osgconf.py
@@ -63,6 +63,7 @@ class Config(object):
         self.defaultattr("bake_constraints", True)
         self.defaultattr("bake_frame_step", 1)
         self.defaultattr("arm_rest", False)
+        self.defaultattr("arm_deform_only", True)
         self.defaultattr("osgconv_to_ive", False)
         self.defaultattr("scale_factor", 1)
         osgconv_util = "osgconv"

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1633,7 +1633,8 @@ class BlenderAnimationToAnimation(object):
                                                         self.config.bake_frame_step,
                                                         self.object,
                                                         use_quaternions=self.config.use_quaternions,
-                                                        has_action=self.has_action)
+                                                        has_action=self.has_action,
+                                                        deform_only=self.config.arm_deform_only)
             self.baked_actions.append(self.current_action)
         self.action_name = self.object.animation_data.action.name if self.has_action else 'Action_baked'
 

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -461,31 +461,17 @@ class Export(object):
         for bone in blender_object.data.bones:
             if bone.parent is None:
                 root_bones.append(bone)
-        
-        def isDeform(bone):
-            if bone.use_deform:
-                return True
-            for b in bone.children_recursive:
-                if b.use_deform:
-                    return True
-        
-        if self.config.arm_deform_only:            
-            for bone in root_bones:
-                if isDeform(bone):
-                    b = Bone(blender_object, bone)
-                    b.buildBoneChildren(use_pose=use_pose,
-                                        scale_factor=self.config.scale_factor,
-                                        deform_only=self.config.arm_deform_only
-                                        )
-                    skeleton.children.append(b)        
-        else:
-            for bone in root_bones:
+
+        for bone in root_bones:
+            if self.config.arm_deform_only and not isDeform(bone):
+                continue
+            else:
                 b = Bone(blender_object, bone)
                 b.buildBoneChildren(use_pose=use_pose,
                                     scale_factor=self.config.scale_factor,
                                     deform_only=self.config.arm_deform_only
                                     )
-                skeleton.children.append(b)            
+                skeleton.children.append(b)        
         skeleton.collectBones()
 
         if use_pose and blender_object in self.rest_armatures:

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -462,10 +462,30 @@ class Export(object):
             if bone.parent is None:
                 root_bones.append(bone)
         
-        for bone in root_bones:
-            b = Bone(blender_object, bone)
-            b.buildBoneChildren(use_pose=use_pose, scale_factor=self.config.scale_factor)
-            skeleton.children.append(b)
+        def isDeform(bone):
+            if bone.use_deform:
+                return True
+            for b in bone.children_recursive:
+                if b.use_deform:
+                    return True
+        
+        if self.config.arm_deform_only:            
+            for bone in root_bones:
+                if isDeform(bone):
+                    b = Bone(blender_object, bone)
+                    b.buildBoneChildren(use_pose=use_pose,
+                                        scale_factor=self.config.scale_factor,
+                                        deform_only=self.config.arm_deform_only
+                                        )
+                    skeleton.children.append(b)        
+        else:
+            for bone in root_bones:
+                b = Bone(blender_object, bone)
+                b.buildBoneChildren(use_pose=use_pose,
+                                    scale_factor=self.config.scale_factor,
+                                    deform_only=self.config.arm_deform_only
+                                    )
+                skeleton.children.append(b)            
         skeleton.collectBones()
 
         if use_pose and blender_object in self.rest_armatures:

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -24,6 +24,7 @@ import bpy
 import json
 import mathutils
 from collections import OrderedDict
+from .osgutils import isDeform
 
 Matrix = mathutils.Matrix
 Vector = mathutils.Vector
@@ -1220,22 +1221,11 @@ class Bone(MatrixTransform):
         
         if not self.bone.children:
             return
-        
-        def isDeform(bone):
-            if bone.use_deform:
-                return True
-            for b in bone.children_recursive:
-                if b.use_deform:
-                    return True
-        
-        if deform_only:
-            for boneChild in self.bone.children:
-                if isDeform(boneChild):
-                    b = Bone(self.skeleton, boneChild, self)
-                    self.children.append(b)
-                    b.buildBoneChildren(use_pose, scale_factor, deform_only)
-        else:
-            for boneChild in self.bone.children:
+
+        for boneChild in self.bone.children:
+            if deform_only and not isDeform(boneChild):
+                continue
+            else:
                 b = Bone(self.skeleton, boneChild, self)
                 self.children.append(b)
                 b.buildBoneChildren(use_pose, scale_factor, deform_only)

--- a/exporter/osg/osgobject.py
+++ b/exporter/osg/osgobject.py
@@ -1184,7 +1184,7 @@ class Bone(MatrixTransform):
         # self.inverse_bind_matrix = Matrix().to_4x4().identity()
         self.bone_inv_bind_matrix_skeleton = Matrix().to_4x4()
 
-    def buildBoneChildren(self, use_pose=False, scale_factor=1.0, deform_only=True):
+    def buildBoneChildren(self, use_pose=False, scale_factor=1.0, deform_only=False):
         if self.skeleton is None or self.bone is None:
             return
 

--- a/exporter/osg/osgutils.py
+++ b/exporter/osg/osgutils.py
@@ -176,6 +176,16 @@ def hasNLATracks(blender_object):
         blender_object.animation_data.nla_tracks
 
 
+def isDeform(bone):
+    if bone.use_deform:
+        return True
+    for b in bone.children_recursive:
+        if b.use_deform:
+            return True
+    
+    return False
+
+
 def isRigAction(action):
     for curve in action.fcurves:
         if 'pose.bones' in curve.data_path:


### PR DESCRIPTION
A properly done rig in Blender contains many more bones than strictly those required to deform geometry. These extra bones allow for complex rigs that make animation easier but are not needed in the exported file.

This MR adds an option to filter bones (and their corresponding animation data) based on the bones' _Deform_ flag. It's the same option available in fbx, gltf, and collada exporters.

When a bone with _Deform_ enabled is present in the rig's hierarchy, its parents need to be exported as well. This ensures predictable exported animation result but requires users to set up their rigs properly with non-deform bones in their own branch of the rig's hierarchy. Again, its the same behaviour as with other exporters. 

I tested this on OpenMW's Land racer and everything looks to perform as expected - only the deform bones and animation channels get included in the exported file. [land_racer.osgt.zip](https://github.com/OpenMW/osgexport/files/11713096/land_racer.osgt.zip)

The option is exposed in the exporter's UI.
![osg_deform_only](https://github.com/OpenMW/osgexport/assets/3763179/9a5b5509-554d-4608-9bbb-ab3917518ca5)
