### PR TITLE
Functionality to export textkeys

### DIFF
--- a/exporter/osg/__init__.py
+++ b/exporter/osg/__init__.py
@@ -312,6 +312,13 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         description="Create a textures folder in the same location as the exported file",
         default=False
         )
+    
+    EXPORT_TEXTKEYS : BoolProperty(
+        name="Export Textkeys",
+        description="Export a textkeys file based on pose markers in each exported action."
+                     " Needed to define animations for OpenMW",
+        default=False,
+        )
 
     def draw(self, context):
         pass
@@ -357,6 +364,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.EXPORT_ALL_SCENES = self.config.export_all_scenes
         self.SCALE_FACTOR = self.config.scale_factor
         self.EXPORT_TEXTURES = self.config.export_textures
+        self.EXPORT_TEXTKEYS = self.config.export_textkeys
 
         if bpy.data.filepath in self.config.history:
             self.filepath = self.config.history[bpy.data.filepath]
@@ -398,6 +406,7 @@ class OSGGUI(bpy.types.Operator, ExportHelper):
         self.config.osgconv_cleanup = self.OSGCONV_CLEANUP
         self.config.scale_factor = self.SCALE_FACTOR
         self.config.export_textures = self.EXPORT_TEXTURES
+        self.config.export_textkeys = self.EXPORT_TEXTKEYS
 
         try:
             cfg = os.path.join(bpy.utils.user_resource('CONFIG'), "osgExport.cfg")
@@ -569,6 +578,7 @@ class OSGT_PT_export_animation(bpy.types.Panel):
         col.prop(operator, 'BAKE_ALL')
         col.prop(operator, 'BAKE_CONSTRAINTS')
         col.prop(operator, 'USE_QUATERNIONS')
+        col.prop(operator, 'EXPORT_TEXTKEYS')
 
 
 class OSGT_PT_export_postprocess(bpy.types.Panel):

--- a/exporter/osg/osgconf.py
+++ b/exporter/osg/osgconf.py
@@ -81,6 +81,7 @@ class Config(object):
 
         self.defaultattr("history", {})
         self.defaultattr("export_textures", False)
+        self.defaultattr("export_textkeys", False)
 
         self.filepath = ""
         self.fullpath = ""

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -315,6 +315,43 @@ class Export(object):
                 osg_object.update_callbacks = []
             osg_object.update_callbacks.append(update_callback)
 
+    def exportTextkeys(self, blender_object, filepath):
+        """
+        Writes a .txt file containing textkeys,
+        which are animation definitions
+        needed by the OpenMW game engine.
+        """
+        context = bpy.context
+        scene = context.scene
+        textkeys_output = open(filepath, "w")
+        markers = []
+        strips_cache = []
+
+        # Gather all relevant strips
+        for track in blender_object.animation_data.nla_tracks:
+            if track.mute:
+                continue
+            for strip in track.strips:
+                if strip.mute:
+                    continue
+                strips_cache.append(strip)
+        
+        # Gather all relevant markers
+        for s in sorted(strips_cache, key=lambda x: x.frame_start):        
+            for m in sorted(s.action.pose_markers, key=lambda x: x.frame):
+                # Frame offset based on the parent strip scale and
+                # position in the NLA editor.
+                frame = (m.frame * s.scale
+                        - (s.scale - 1)
+                        + s.frame_start - 1)
+                frame = frame * 1/scene.render.fps
+                # Textkeys don't work if they are not lower case.
+                markers.append(("{} {}").format(str(m.name), str(frame)).lower())
+
+        for m in markers:
+            textkeys_output.write(m + '\n')
+        textkeys_output.close()
+
     def exportChildrenRecursively(self, blender_object, parent, osg_root):
         def parseArmature(blender_armature):
             osg_object = self.createSkeleton(blender_object)
@@ -324,6 +361,10 @@ class Export(object):
                                                               rotation_mode),
                                         self.unique_objects,
                                         self.parse_all_actions)
+            
+            if self.config.export_textkeys:
+                self.exportTextkeys(blender_armature, self.config.getFullName("txt"))
+                
             return osg_object
 
         def parseLight(blender_light):
@@ -1678,6 +1719,10 @@ class BlenderAnimationToAnimation(object):
                     parseSolidRigAction()
             elif hasShapeKeys(self.object):
                 parseMorphAction()
+        
+        for track in self.object.animation_data.nla_tracks:
+            for strip in track.strips:
+                print(strip.name)
 
         return anims
 
@@ -1778,7 +1823,6 @@ class BlenderAnimationToAnimation(object):
 
         return channel
 
-    # as for blender 2.49
     def exportActionsToKeyframeSplitRotationTranslationScale(self, target, action, fps, prefix, osg_targetname=''):
         channels = []
 

--- a/exporter/osg/osgdata.py
+++ b/exporter/osg/osgdata.py
@@ -1719,10 +1719,6 @@ class BlenderAnimationToAnimation(object):
                     parseSolidRigAction()
             elif hasShapeKeys(self.object):
                 parseMorphAction()
-        
-        for track in self.object.animation_data.nla_tracks:
-            for strip in track.strips:
-                print(strip.name)
 
         return anims
 


### PR DESCRIPTION
Textkeys are OpenMW's animation definition files. This MR adds an option to export them based off pose markers. These pose markers reside in NLA (animation) strips assigned to the rig object.

Exporting of textkeys works the same and produces the same result as the collada exporter.